### PR TITLE
Work queue cleanup

### DIFF
--- a/apps/scanner_agent/package.json
+++ b/apps/scanner_agent/package.json
@@ -12,14 +12,16 @@
     "dependencies": {
         "@types/throng": "^5.0.4",
         "bull": "^4.10.4",
-        "express": "^4.18.2",
         "common-helpers": "*",
+        "express": "^4.18.2",
+        "milliseconds": "^1.0.3",
         "s3-helpers": "*",
         "throng": "^5.0.0"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",
         "@types/express": "^4.17.17",
+        "@types/milliseconds": "^0.0.30",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.15.11",
         "chai": "^4.3.7",

--- a/apps/scanner_agent/src/worker.ts
+++ b/apps/scanner_agent/src/worker.ts
@@ -112,6 +112,7 @@ const start = (): void => {
             return {
                 result
             }
+
         } catch (error) {
             console.log("Error:", error);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,12 +63,14 @@
                 "bull": "^4.10.4",
                 "common-helpers": "*",
                 "express": "^4.18.2",
+                "milliseconds": "^1.0.3",
                 "s3-helpers": "*",
                 "throng": "^5.0.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
                 "@types/express": "^4.17.17",
+                "@types/milliseconds": "^0.0.30",
                 "@types/mocha": "^10.0.1",
                 "@types/node": "^18.15.11",
                 "chai": "^4.3.7",
@@ -2260,6 +2262,12 @@
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+        },
+        "node_modules/@types/milliseconds": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/milliseconds/-/milliseconds-0.0.30.tgz",
+            "integrity": "sha512-MVgBCpNG6tuPctUGqaGsbMLm5E4bYy8Ki7G4RMmcMH83e15iMY9L7bJccWpXv3Zyo8y0GQlvUj+yOShWlQlTOA==",
+            "dev": true
         },
         "node_modules/@types/mime": {
             "version": "1.3.2",
@@ -5693,6 +5701,11 @@
             "engines": {
                 "node": ">=8.6"
             }
+        },
+        "node_modules/milliseconds": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/milliseconds/-/milliseconds-1.0.3.tgz",
+            "integrity": "sha512-O8fANvJPdQULWgsLW+jyyPMAw4qiiPHGQDF7lXQmOXLXbmjphetpOYBk5Tut/74Q3EZ66g7TbvXw5RRi1wnJPQ=="
         },
         "node_modules/mime": {
             "version": "1.6.0",


### PR DESCRIPTION
This PR implements some cleanup for the REDIS work queue.  Currently, any "completed" or "failed" job that is older than 5 days gets cleaned up from the work queue.  By doing this, accessing the /jobs node is kept within a reasonable response time of some seconds.