### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Double Open Oy
+#
+# SPDX-License-Identifier: MIT
+
+* @doubleopen-project/devs

--- a/apps/curation_front_end/src/pages/packages/index.tsx
+++ b/apps/curation_front_end/src/pages/packages/index.tsx
@@ -7,7 +7,9 @@ import { userHooks } from "../../hooks/zodiosHooks";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default function PackageLibrary() {
-  const { data, isLoading, error } = userHooks.useGet("/packages", { withCredentials: true });
+  const { data, isLoading, error } = userHooks.useGet("/packages", {
+    withCredentials: true,
+  });
   if (isLoading) {
     return <div>Loading package list...</div>;
   }


### PR DESCRIPTION
GitHub's CODEOWNERS file is used to automatically assign code reviewers.