### PR TITLE
Do 266 indicate path exclusions in packagetree

### DIFF
--- a/apps/curation_front_end/package.json
+++ b/apps/curation_front_end/package.json
@@ -45,7 +45,8 @@
         "tailwind-merge": "1.14.0",
         "tailwindcss-animate": "1.0.7",
         "validation-helpers": "*",
-        "zod": "3.22.4"
+        "zod": "3.22.4",
+        "minimatch": "^9.0.3"
     },
     "devDependencies": {
         "@types/js-yaml": "4.0.8",

--- a/apps/curation_front_end/src/components/ExclusionForm.tsx
+++ b/apps/curation_front_end/src/components/ExclusionForm.tsx
@@ -74,16 +74,6 @@ const ExclusionForm = ({ purl }: Props) => {
     );
 
     const onSubmit = (data: ExclusionFormType) => {
-        console.log(
-            "purl=",
-            purl,
-            "pattern=",
-            data.pattern,
-            "reason=",
-            data.reason,
-            "comment=",
-            data.comment,
-        );
         addPathExclusion({
             purl: purl,
             pattern: data.pattern,

--- a/apps/curation_front_end/src/components/Node.tsx
+++ b/apps/curation_front_end/src/components/Node.tsx
@@ -69,7 +69,7 @@ const Node = ({ node, style, purl, licenseFilter }: NodeProps) => {
                     }}
                 >
                     <span className="flex items-center">{icon}</span>
-                    <span className="ml-1 font-mono text-xs">
+                    <span className="ml-1 font-mono text-xs flex-grow truncate">
                         {isLeaf ? (
                             <Link
                                 href={{
@@ -81,10 +81,12 @@ const Node = ({ node, style, purl, licenseFilter }: NodeProps) => {
                                         : {},
                                 }}
                             >
-                                <div className={selectedClassName}>{name}</div>
+                                <span className={selectedClassName}>
+                                    {name}
+                                </span>
                             </Link>
                         ) : (
-                            <div className={selectedClassName}>{name}</div>
+                            <span className={selectedClassName}>{name}</span>
                         )}
                     </span>
                 </div>

--- a/apps/curation_front_end/src/components/Node.tsx
+++ b/apps/curation_front_end/src/components/Node.tsx
@@ -19,43 +19,26 @@ import {
     ContextMenuRadioGroup,
     ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { Label } from "@/components/ui/label";
-import { minimatch } from "minimatch";
-import { userAPI } from "validation-helpers";
-import { ZodiosResponseByPath } from "@zodios/core";
-
-type PathExclusionProps = ZodiosResponseByPath<
-    typeof userAPI,
-    "post",
-    "/path-exclusions"
->;
 
 type NodeProps = NodeRendererProps<any> & {
     purl: string | undefined;
     licenseFilter: string | null;
-    pathExclusions: PathExclusionProps | undefined;
 };
 
-const Node = ({
-    node,
-    style,
-    purl,
-    licenseFilter,
-    pathExclusions,
-}: NodeProps) => {
-    const { isLeaf, isInternal, isClosed, isSelected, data } = node;
-    const { hasLicenseFindings, hasLicenseConclusions, name, path, children } =
-        data;
+const Node = ({ node, style, purl, licenseFilter }: NodeProps) => {
+    const { isLeaf, isClosed, isSelected, data } = node;
+    const {
+        hasLicenseFindings,
+        hasLicenseConclusions,
+        isExcluded,
+        name,
+        path,
+    } = data;
     const boldStyle = { strokeWidth: 0.5 };
     let color;
     let icon;
     let isBold = false;
     let selectedClassName;
-
-    const patterns = pathExclusions?.pathExclusions.map(
-        (exclusion) => exclusion.pattern,
-    );
-    const isExcluded = patterns?.some((pattern) => minimatch(path, pattern));
 
     if (isSelected) {
         selectedClassName = "bg-gray-400 rounded-sm";

--- a/apps/curation_front_end/src/components/PackageTree.tsx
+++ b/apps/curation_front_end/src/components/PackageTree.tsx
@@ -24,20 +24,15 @@ import {
     DialogContent,
     DialogFooter,
 } from "@/components/ui/dialog";
-import {
-    DropdownMenu,
-    DropdownMenuTrigger,
-    DropdownMenuContent,
-} from "@/components/ui/dropdown-menu";
 import ExclusionForm from "@/components/ExclusionForm";
 import ExclusionList from "@/components/ExclusionList";
 import { DialogClose } from "@radix-ui/react-dialog";
 
-type PackageTreeProps = {
+type Props = {
     purl: string | undefined;
 };
 
-const PackageTree = ({ purl }: PackageTreeProps) => {
+const PackageTree = ({ purl }: Props) => {
     const [treeFilter, setTreeFilter] = useState("");
     const [licenseFilter, setLicenseFilter] = useQueryState(
         "licenseFilter",
@@ -49,8 +44,17 @@ const PackageTree = ({ purl }: PackageTreeProps) => {
     const [originalTreeData, setOriginalTreeData] = useState<TreeNode[]>([]);
     const treeRef = useRef<HTMLDivElement>(null);
 
+    // Fetch the package file tree data
     const { data, isLoading, error } = userHooks.useImmutableQuery(
         "/filetree",
+        { purl: purl as string },
+        { withCredentials: true },
+        { enabled: !!purl },
+    );
+
+    // Fetch the path exclusions for the package
+    const { data: pathExclusions } = userHooks.useImmutableQuery(
+        "/path-exclusions",
         { purl: purl as string },
         { withCredentials: true },
         { enabled: !!purl },
@@ -143,7 +147,7 @@ const PackageTree = ({ purl }: PackageTreeProps) => {
                         <Loader2 className="mr-2 h-16 w-16 animate-spin" />
                     </div>
                 )}
-                {data && (
+                {data && pathExclusions && (
                     <Tree
                         className=""
                         data={treeData}
@@ -168,6 +172,7 @@ const PackageTree = ({ purl }: PackageTreeProps) => {
                                 {...nodeProps}
                                 licenseFilter={licenseFilter}
                                 purl={purl}
+                                pathExclusions={pathExclusions}
                             />
                         )}
                     </Tree>

--- a/apps/curation_front_end/src/components/PackageTree.tsx
+++ b/apps/curation_front_end/src/components/PackageTree.tsx
@@ -110,12 +110,17 @@ const PackageTree = ({ purl }: Props) => {
 
     // Return the whole original tree data when the license search text is empty
     useEffect(() => {
-        if (data) {
-            const convertedData = convertJsonToTree(data.filetrees);
+        if (data && pathExclusions) {
+            const convertedData = convertJsonToTree(
+                data.filetrees,
+                pathExclusions.pathExclusions.map(
+                    (exclusion) => exclusion.pattern,
+                ),
+            );
             setTreeData(convertedData);
             setOriginalTreeData(convertedData);
         }
-    }, [data]);
+    }, [data, pathExclusions]);
 
     return (
         <div className="flex flex-col h-full">
@@ -172,7 +177,6 @@ const PackageTree = ({ purl }: Props) => {
                                 {...nodeProps}
                                 licenseFilter={licenseFilter}
                                 purl={purl}
-                                pathExclusions={pathExclusions}
                             />
                         )}
                     </Tree>

--- a/apps/curation_front_end/src/helpers/convertJsonToTree.ts
+++ b/apps/curation_front_end/src/helpers/convertJsonToTree.ts
@@ -26,7 +26,7 @@ export const convertJsonToTree = (filetrees: FileTreeType[]): TreeNode[] => {
                 const newNode: TreeNode = {
                     id: id.toString(),
                     name: part,
-                    path: isLastPart ? fileTree.path : undefined,
+                    path: fullPath,
                     fileSha256: isLastPart ? fileTree.fileSha256 : undefined,
                     hasLicenseFindings: false,
                     hasLicenseConclusions: false,

--- a/apps/curation_front_end/src/helpers/convertJsonToTree.ts
+++ b/apps/curation_front_end/src/helpers/convertJsonToTree.ts
@@ -5,8 +5,13 @@
 import type { FileTreeType } from "validation-helpers";
 import type { TreeNode } from "../types";
 import { sortTree } from "./sortTree";
+import { minimatch } from "minimatch";
+import { updateExclusionStatus } from "./updateExclusionStatus";
 
-export const convertJsonToTree = (filetrees: FileTreeType[]): TreeNode[] => {
+export const convertJsonToTree = (
+    filetrees: FileTreeType[],
+    patterns?: string[],
+): TreeNode[] => {
     let id = 1; // Initialize a unique ID counter
     const root: TreeNode[] = []; // Initialize an empty root
     const map: { [key: string]: TreeNode } = {}; // Maintain a mapping from directory name to TreeNode object
@@ -22,6 +27,12 @@ export const convertJsonToTree = (filetrees: FileTreeType[]): TreeNode[] => {
 
             fullPath += (i > 0 ? "/" : "") + part;
 
+            // Determine if the current node's path matches any of the provided patterns
+            const isExcluded =
+                patterns?.some((pattern) =>
+                    minimatch(fullPath, pattern, { dot: true }),
+                ) || false;
+
             if (!map[fullPath]) {
                 const newNode: TreeNode = {
                     id: id.toString(),
@@ -30,6 +41,7 @@ export const convertJsonToTree = (filetrees: FileTreeType[]): TreeNode[] => {
                     fileSha256: isLastPart ? fileTree.fileSha256 : undefined,
                     hasLicenseFindings: false,
                     hasLicenseConclusions: false,
+                    isExcluded: isExcluded,
                     file: {
                         licenseFindings: isLastPart
                             ? fileTree.file.licenseFindings
@@ -74,6 +86,9 @@ export const convertJsonToTree = (filetrees: FileTreeType[]): TreeNode[] => {
                 }
             }
 
+            // Update isExcluded for existing nodes
+            map[fullPath].isExcluded = isExcluded;
+
             // Propagate the hasLicenseFindings and hasLicenseConclusions flags to ancestor directories
             if (
                 fileTree.file.licenseFindings.length > 0 ||
@@ -92,11 +107,14 @@ export const convertJsonToTree = (filetrees: FileTreeType[]): TreeNode[] => {
                     }
                 }
             }
-
             if (!isLastPart) {
                 currentNode = map[fullPath].children!;
             }
         }
+    }
+    // Update the exclusion status of all nodes
+    for (const node of root) {
+        updateExclusionStatus(node);
     }
 
     return sortTree(root);

--- a/apps/curation_front_end/src/helpers/updateExclusionStatus.ts
+++ b/apps/curation_front_end/src/helpers/updateExclusionStatus.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2023 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { TreeNode } from "../types";
+
+// Update the exclusion status of an internal node
+// based on the exclusion status of its children:
+// - If all children are excluded, the node is excluded
+// - If any child is not excluded, the node is not excluded
+export const updateExclusionStatus = (node: TreeNode): boolean => {
+    if (!node.children || node.children.length === 0) {
+        return node.isExcluded || false;
+    }
+
+    let allChildrenExcluded = true;
+    for (const child of node.children) {
+        const childExcluded = updateExclusionStatus(child);
+        allChildrenExcluded = allChildrenExcluded && childExcluded;
+    }
+
+    node.isExcluded = allChildrenExcluded;
+    return node.isExcluded;
+};

--- a/apps/curation_front_end/src/types/index.ts
+++ b/apps/curation_front_end/src/types/index.ts
@@ -9,6 +9,7 @@ export type TreeNode = {
     fileSha256?: string;
     hasLicenseFindings: boolean;
     hasLicenseConclusions: boolean;
+    isExcluded?: boolean;
     file?: {
         licenseFindings: LicenseFindings[];
         licenseConclusions: LicenseConclusions[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
                 "packages/*",
                 "apps/*"
             ],
-            "dependencies": {
-                "minimatch": "^9.0.3"
-            },
             "devDependencies": {
                 "prettier": "3.0.3",
                 "rimraf": "5.0.5",
@@ -102,6 +99,7 @@
                 "cmdk": "0.2.0",
                 "js-yaml": "4.1.0",
                 "lucide-react": "0.288.0",
+                "minimatch": "^9.0.3",
                 "next-themes": "0.2.1",
                 "next-usequerystate": "1.8.4",
                 "react-arborist": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
                 "packages/*",
                 "apps/*"
             ],
+            "dependencies": {
+                "minimatch": "^9.0.3"
+            },
             "devDependencies": {
                 "prettier": "3.0.3",
                 "rimraf": "5.0.5",
@@ -4916,7 +4919,6 @@
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -9789,8 +9791,8 @@
         },
         "node_modules/minimatch": {
             "version": "9.0.3",
-            "dev": true,
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "packageManager": "npm@9.5.0",
     "overrides": {
         "formidable": "1.2.6"
+    },
+    "dependencies": {
+        "minimatch": "^9.0.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
     "packageManager": "npm@9.5.0",
     "overrides": {
         "formidable": "1.2.6"
-    },
-    "dependencies": {
-        "minimatch": "^9.0.3"
     }
 }


### PR DESCRIPTION
This PR implements calculating and showing path exclusions with gray icon color for all path exclusions.  It conforms to ORT Glob definition(`*, ?, **`), with the exception that for directory exclusions (for example, `apps/src/**`), also the root directory (in this case, `apps/src`) is marked as excluded, although it doesn't match the Glob.  The reason is UX related; for directory exclusions, it is essential that PackageTree component also shows the directory itself as being excluded.