### PR TITLE
Implement Zustand for mode toggle for future use

### DIFF
--- a/apps/curation_front_end/package.json
+++ b/apps/curation_front_end/package.json
@@ -49,7 +49,8 @@
         "tailwind-merge": "1.14.0",
         "tailwindcss-animate": "1.0.7",
         "validation-helpers": "*",
-        "zod": "3.22.4"
+        "zod": "3.22.4",
+        "zustand": "^4.4.6"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "5.16.5",

--- a/apps/curation_front_end/src/components/ModeToggle.tsx
+++ b/apps/curation_front_end/src/components/ModeToggle.tsx
@@ -10,12 +10,16 @@ import { Button } from "@/components/ui/button";
 import {
     DropdownMenu,
     DropdownMenuContent,
-    DropdownMenuItem,
     DropdownMenuTrigger,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
 } from "@/components/ui/dropdown-menu";
+import useThemeStore from "@/store/theme.store";
 
 export function ModeToggle() {
     const { setTheme } = useTheme();
+    const appTheme = useThemeStore((state) => state.appTheme);
+    const setAppTheme = useThemeStore((state) => state.setAppTheme);
 
     return (
         <DropdownMenu>
@@ -27,15 +31,29 @@ export function ModeToggle() {
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setTheme("light")}>
-                    Light
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("dark")}>
-                    Dark
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("system")}>
-                    System
-                </DropdownMenuItem>
+                <DropdownMenuRadioGroup
+                    value={appTheme}
+                    onValueChange={(value) => setAppTheme(value)}
+                >
+                    <DropdownMenuRadioItem
+                        value="light"
+                        onClick={() => setTheme("light")}
+                    >
+                        Light
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem
+                        value="dark"
+                        onClick={() => setTheme("dark")}
+                    >
+                        Dark
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem
+                        value="system"
+                        onClick={() => setTheme("system")}
+                    >
+                        System
+                    </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/apps/curation_front_end/src/store/theme.store.ts
+++ b/apps/curation_front_end/src/store/theme.store.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+// This is an example of a store that uses zustand, storing the theme of the app.
+// (The theme is persisted by next-themes anyway, so this is only here for a future use.)
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type State = {
+    appTheme: string;
+};
+
+type Actions = {
+    setAppTheme: (appTheme: string) => void;
+};
+
+const useThemeStore = create<State & Actions>()(
+    persist(
+        (set) => ({
+            appTheme: "light",
+            setAppTheme: (appTheme: string) => set({ appTheme }),
+        }),
+        {
+            name: "theme-storage",
+        },
+    ),
+);
+
+export default useThemeStore;

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,8 @@
                 "tailwind-merge": "1.14.0",
                 "tailwindcss-animate": "1.0.7",
                 "validation-helpers": "*",
-                "zod": "3.22.4"
+                "zod": "3.22.4",
+                "zustand": "^4.4.6"
             },
             "devDependencies": {
                 "@testing-library/jest-dom": "5.16.5",
@@ -18568,6 +18569,33 @@
             "license": "ISC",
             "peerDependencies": {
                 "zod": "^3.19.0"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
+            "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+            "dependencies": {
+                "use-sync-external-store": "1.2.0"
+            },
+            "engines": {
+                "node": ">=12.7.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.8",
+                "immer": ">=9.0",
+                "react": ">=16.8"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
             }
         },
         "packages/common-helpers": {


### PR DESCRIPTION
With this PR, Zustand is installed for managing client state. As a trivial example, it includes Zustand implementation for persisting app theme (next-themes persists it anyway, so this only serves as an example for using Zustand).  You can monitor the persisted Zustand state from webtools/storage/local storage.