### PR TITLE
Do 288 add filter toggle to curation UI

### DIFF
--- a/apps/curation_front_end/package.json
+++ b/apps/curation_front_end/package.json
@@ -26,6 +26,7 @@
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "1.0.2",
         "@radix-ui/react-toast": "1.1.5",
+        "@radix-ui/react-toggle": "^1.0.3",
         "@radix-ui/react-tooltip": "1.0.7",
         "@tanstack/react-query": "4.35.3",
         "@tanstack/react-query-devtools": "4.35.3",

--- a/apps/curation_front_end/src/components/package_inspector/ComboBoxPackage.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/ComboBoxPackage.tsx
@@ -42,7 +42,7 @@ const ComboBoxPackage = ({ data, filterString }: ComboBoxPackageProps) => {
         filterString,
         parseAsString.withDefault(""),
     );
-    const [filtering, setFiltering] = useQueryState(
+    const [, setFiltering] = useQueryState(
         "filtering",
         parseAsBoolean.withDefault(false),
     );

--- a/apps/curation_front_end/src/components/package_inspector/ComboBoxPackage.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/ComboBoxPackage.tsx
@@ -22,7 +22,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { Check, ChevronsUpDown, X } from "lucide-react";
+import { Check, ChevronsUpDown, XCircle } from "lucide-react";
 import { parseAsString, useQueryState } from "next-usequerystate";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
@@ -105,15 +105,18 @@ const ComboBoxPackage = ({ data, filterString }: ComboBoxPackageProps) => {
             </Popover>
             <TooltipProvider delayDuration={300}>
                 <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            variant="destructive"
-                            className="h-fit w-1/6"
-                            onClick={() => setValue(null)}
-                            disabled={value === ""}
-                        >
-                            <X className="w-4 h-4 shrink-0" />
-                        </Button>
+                    <TooltipTrigger
+                        className="ml-1"
+                        type="button"
+                        onClick={() => setValue(null)}
+                        disabled={value === ""}
+                    >
+                        <XCircle
+                            className={cn(
+                                "mx-2 text-gray-400 h-fit",
+                                !value ? "opacity-40" : "opacity-100",
+                            )}
+                        />
                     </TooltipTrigger>
                     <TooltipContent>Remove license filtering</TooltipContent>
                 </Tooltip>

--- a/apps/curation_front_end/src/components/package_inspector/ComboBoxPackage.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/ComboBoxPackage.tsx
@@ -23,9 +23,13 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown, XCircle } from "lucide-react";
-import { parseAsString, useQueryState } from "next-usequerystate";
+import {
+    parseAsBoolean,
+    parseAsString,
+    useQueryState,
+} from "next-usequerystate";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 type ComboBoxPackageProps = {
     data: Set<string>;
@@ -38,6 +42,10 @@ const ComboBoxPackage = ({ data, filterString }: ComboBoxPackageProps) => {
         filterString,
         parseAsString.withDefault(""),
     );
+    const [filtering, setFiltering] = useQueryState(
+        "filtering",
+        parseAsBoolean.withDefault(false),
+    );
     const router = useRouter();
 
     // Map data to the format required by the Command component
@@ -45,6 +53,14 @@ const ComboBoxPackage = ({ data, filterString }: ComboBoxPackageProps) => {
         value: license.toLowerCase(),
         label: license,
     }));
+
+    // If the license filter is set, set "filtering" to true.
+    // Do it as a side effect to avoid infinite loop
+    useEffect(() => {
+        if (value) {
+            setFiltering(true);
+        }
+    }, [value]);
 
     return (
         <div className="flex flex-row justify-between w-full">
@@ -108,7 +124,10 @@ const ComboBoxPackage = ({ data, filterString }: ComboBoxPackageProps) => {
                     <TooltipTrigger
                         className="ml-1"
                         type="button"
-                        onClick={() => setValue(null)}
+                        onClick={() => {
+                            setValue(null);
+                            setFiltering(null);
+                        }}
                         disabled={value === ""}
                     >
                         <XCircle

--- a/apps/curation_front_end/src/components/package_inspector/Node.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/Node.tsx
@@ -15,9 +15,10 @@ import { MdArrowDropDown, MdArrowRight } from "react-icons/md";
 type NodeProps = NodeRendererProps<TreeNode> & {
     purl: string | undefined;
     licenseFilter: string | null;
+    filtering: boolean;
 };
 
-const Node = ({ node, style, purl, licenseFilter }: NodeProps) => {
+const Node = ({ node, style, purl, licenseFilter, filtering }: NodeProps) => {
     const { isLeaf, isClosed, isFocused, data } = node;
     const {
         hasLicenseFindings,
@@ -92,6 +93,7 @@ const Node = ({ node, style, purl, licenseFilter }: NodeProps) => {
                             query: licenseFilter
                                 ? {
                                       licenseFilter: `${licenseFilter}`,
+                                      filtering: `${filtering}`,
                                   }
                                 : {},
                         }}

--- a/apps/curation_front_end/src/components/package_inspector/PackageTree.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/PackageTree.tsx
@@ -9,6 +9,7 @@ import ExclusionTools from "@/components/path_exclusions/ExclusionTools";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Toggle } from "@/components/ui/toggle";
 import { convertJsonToTree } from "@/helpers/convertJsonToTree";
 import { extractUniqueLicenses } from "@/helpers/extractUniqueLicenses";
 import { filterTreeDataByLicense } from "@/helpers/filterTreeDataByLicense";
@@ -16,7 +17,11 @@ import { updateHasLicenseFindings } from "@/helpers/updateHasLicenseFindings";
 import { userHooks } from "@/hooks/zodiosHooks";
 import type { SelectedNode, TreeNode } from "@/types/index";
 import { Loader2 } from "lucide-react";
-import { parseAsString, useQueryState } from "next-usequerystate";
+import {
+    parseAsBoolean,
+    parseAsString,
+    useQueryState,
+} from "next-usequerystate";
 import React, { useEffect, useRef, useState } from "react";
 import { Tree, TreeApi } from "react-arborist";
 import { Button } from "../ui/button";
@@ -30,6 +35,10 @@ const PackageTree = ({ purl }: Props) => {
     const [licenseFilter] = useQueryState(
         "licenseFilter",
         parseAsString.withDefault(""),
+    );
+    const [filtering, setFiltering] = useQueryState(
+        "filtering",
+        parseAsBoolean.withDefault(false),
     );
     const [isExpanded, setIsExpanded] = useState(false);
     const [treeHeight, setTreeHeight] = useState(0);
@@ -54,23 +63,16 @@ const PackageTree = ({ purl }: Props) => {
         { enabled: !!purl },
     );
 
-    const handleTreeFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setTreeFilter(event.target.value);
-    };
-
     let tree: TreeApi<TreeNode> | null | undefined;
     const uniqueLicenses = extractUniqueLicenses(originalTreeData);
 
-    const handleExpand = () => {
-        if (!isExpanded) {
-            tree?.openAll();
-            setIsExpanded(true);
-        } else {
-            tree?.closeAll();
-            setIsExpanded(false);
-        }
+    const handleTreeFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setTreeFilter(event.target.value);
     };
-
+    const handleFilterToggle = () => {
+        setFiltering(!filtering);
+        setIsExpanded(!filtering);
+    };
     const handleResize = () => {
         if (treeRef.current) {
             const { offsetHeight } = treeRef.current;
@@ -83,9 +85,9 @@ const PackageTree = ({ purl }: Props) => {
         window.addEventListener("resize", handleResize);
     }, []);
 
-    // Update tree data when the license search text is changed
+    // Update tree data when the license filter is set and filtered is true
     useEffect(() => {
-        if (licenseFilter) {
+        if (licenseFilter && filtering) {
             let updatedTreeData = JSON.parse(JSON.stringify(originalTreeData)); // Create a deep copy
 
             // Filter the tree based on the licenseSearchText
@@ -95,13 +97,14 @@ const PackageTree = ({ purl }: Props) => {
             );
 
             updateHasLicenseFindings(updatedTreeData, licenseFilter); // Update hasLicenseFindings flag
-
             setTreeData(updatedTreeData); // Set the updated and/or filtered tree data to trigger a re-render
+            setIsExpanded(true); // Expand the tree when filtering
         } else {
             // Reset to original tree data if licenseFilter is empty
             setTreeData(originalTreeData);
+            setIsExpanded(false);
         }
-    }, [licenseFilter, originalTreeData]);
+    }, [licenseFilter, filtering, originalTreeData]);
 
     // Return the whole original tree data when the license search text is empty
     useEffect(() => {
@@ -116,6 +119,17 @@ const PackageTree = ({ purl }: Props) => {
             setOriginalTreeData(convertedData);
         }
     }, [data, pathExclusions]);
+
+    // This should have worked without useEffect, as a component should be re-rendered
+    // when the isExpanded state changes. However, it didn't
+    useEffect(() => {
+        console.log("isExpanded: ", isExpanded);
+        if (isExpanded) {
+            tree?.openAll();
+        } else {
+            tree?.closeAll();
+        }
+    }, [isExpanded]);
 
     return (
         <div className="flex flex-col h-full">
@@ -134,14 +148,32 @@ const PackageTree = ({ purl }: Props) => {
                 />
                 <Button
                     className="p-1 ml-2 text-xs rounded-md"
-                    onClick={handleExpand}
+                    onClick={() => setIsExpanded(!isExpanded)}
                     variant={"outline"}
                 >
                     {isExpanded ? "Collapse" : "Expand"}
                 </Button>
             </div>
-
-            <ExclusionTools selectedNode={selectedNode} purl={purl} />
+            <div className="flex items-center justify-between">
+                <div className="flex-1 mr-2 h-full">
+                    <ExclusionTools selectedNode={selectedNode} purl={purl} />
+                </div>
+                <Toggle
+                    className="text-xs"
+                    variant="outline"
+                    disabled={licenseFilter === ""}
+                    pressed={filtering}
+                    onPressedChange={handleFilterToggle}
+                >
+                    {filtering === true ? (
+                        <span className="text-red-500 font-bold">
+                            Filtering
+                        </span>
+                    ) : (
+                        "Filter"
+                    )}
+                </Toggle>
+            </div>
 
             <div className="flex-1 pl-1 overflow-auto" ref={treeRef}>
                 {isLoading && (

--- a/apps/curation_front_end/src/components/package_inspector/PackageTree.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/PackageTree.tsx
@@ -10,6 +10,12 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Toggle } from "@/components/ui/toggle";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { convertJsonToTree } from "@/helpers/convertJsonToTree";
 import { extractUniqueLicenses } from "@/helpers/extractUniqueLicenses";
 import { filterTreeDataByLicense } from "@/helpers/filterTreeDataByLicense";
@@ -69,10 +75,7 @@ const PackageTree = ({ purl }: Props) => {
     const handleTreeFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
         setTreeFilter(event.target.value);
     };
-    const handleFilterToggle = () => {
-        setFiltering(!filtering);
-        setIsExpanded(!filtering);
-    };
+
     const handleResize = () => {
         if (treeRef.current) {
             const { offsetHeight } = treeRef.current;
@@ -158,21 +161,32 @@ const PackageTree = ({ purl }: Props) => {
                 <div className="flex-1 mr-2 h-full">
                     <ExclusionTools selectedNode={selectedNode} purl={purl} />
                 </div>
-                <Toggle
-                    className="text-xs"
-                    variant="outline"
-                    disabled={licenseFilter === ""}
-                    pressed={filtering}
-                    onPressedChange={handleFilterToggle}
-                >
-                    {filtering === true ? (
-                        <span className="text-red-500 font-bold">
-                            Filtering
-                        </span>
-                    ) : (
-                        "Filter"
-                    )}
-                </Toggle>
+                <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Toggle
+                                className="text-xs"
+                                variant="outline"
+                                disabled={licenseFilter === ""}
+                                pressed={filtering}
+                                onPressedChange={() => setFiltering(!filtering)}
+                            >
+                                {filtering ? (
+                                    <span className="text-red-500 font-bold">
+                                        Filtering
+                                    </span>
+                                ) : (
+                                    "Filter"
+                                )}
+                            </Toggle>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            {filtering
+                                ? "Toggle license filter off to show the whole tree"
+                                : "Toggle license filter on to filter the tree by license"}
+                        </TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
             </div>
 
             <div className="flex-1 pl-1 overflow-auto" ref={treeRef}>

--- a/apps/curation_front_end/src/components/package_inspector/PackageTree.tsx
+++ b/apps/curation_front_end/src/components/package_inspector/PackageTree.tsx
@@ -126,7 +126,6 @@ const PackageTree = ({ purl }: Props) => {
     // This should have worked without useEffect, as a component should be re-rendered
     // when the isExpanded state changes. However, it didn't
     useEffect(() => {
-        console.log("isExpanded: ", isExpanded);
         if (isExpanded) {
             tree?.openAll();
         } else {
@@ -220,6 +219,7 @@ const PackageTree = ({ purl }: Props) => {
                             <Node
                                 {...nodeProps}
                                 licenseFilter={licenseFilter}
+                                filtering={filtering}
                                 purl={purl}
                             />
                         )}

--- a/apps/curation_front_end/src/components/ui/toggle.tsx
+++ b/apps/curation_front_end/src/components/ui/toggle.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2023 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { cn } from "@/lib/utils";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+const toggleVariants = cva(
+    "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+    {
+        variants: {
+            variant: {
+                default: "bg-transparent",
+                outline:
+                    "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+            },
+            size: {
+                default: "h-10 px-3",
+                sm: "h-9 px-2.5",
+                lg: "h-11 px-5",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    },
+);
+
+const Toggle = React.forwardRef<
+    React.ElementRef<typeof TogglePrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+        VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+    <TogglePrimitive.Root
+        ref={ref}
+        className={cn(toggleVariants({ variant, size, className }))}
+        {...props}
+    />
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle, toggleVariants };

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
                 "@radix-ui/react-separator": "^1.0.3",
                 "@radix-ui/react-slot": "1.0.2",
                 "@radix-ui/react-toast": "1.1.5",
+                "@radix-ui/react-toggle": "^1.0.3",
                 "@radix-ui/react-tooltip": "1.0.7",
                 "@tanstack/react-query": "4.35.3",
                 "@tanstack/react-query-devtools": "4.35.3",
@@ -3975,6 +3976,31 @@
                 "@radix-ui/react-use-controllable-state": "1.0.1",
                 "@radix-ui/react-use-layout-effect": "1.0.1",
                 "@radix-ui/react-visually-hidden": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz",
+            "integrity": "sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-controllable-state": "1.0.1"
             },
             "peerDependencies": {
                 "@types/react": "*",


### PR DESCRIPTION
This PR adds a filtering toggle button to the UI: when toggled, the filetree is filtered with the chosen license; when toggled off, the whole filetree is shown.  The selected filtering license and filter toggle status are both persisted in the URL for possible link sharing, where the user might want to share the link to his/her view of the package filetree.

This PR also resolves DO-300.