### PR TITLE
Fix the order of given licenses choices in `.ort.yml`

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -36,11 +36,11 @@ license_choices:
       choice: MIT
   - package_id: "NPM::lodash.defaults:4.2.0"
     license_choices:
-    - given: BSD-3-Clause OR GPL-2.0-only OR MIT
+    - given: MIT OR BSD-3-Clause OR GPL-2.0-only
       choice: MIT
   - package_id: "NPM::lodash.isarguments:3.1.0"
     license_choices:
-    - given: BSD-3-Clause OR GPL-2.0-only OR MIT
+    - given: MIT OR BSD-3-Clause OR GPL-2.0-only
       choice: MIT
   - package_id: "NPM::type-fest:0.6.0"
     license_choices:


### PR DESCRIPTION
The order of license operands is significant as `given` is matched literally, not logically.