### PR TITLE
Replace package- with repository-license-choices

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -25,36 +25,10 @@ excludes:
     comment: "This directory only contains test data for the database."
 
 license_choices:
-  package_license_choices:
-  - package_id: "NPM::fraction.js:4.3.7"
-    license_choices:
-    - given: GPL-2.0-only OR MIT
-      choice: MIT
-  - package_id: "NPM::lodash:4.17.21"
-    license_choices:
-    - given: MIT OR BSD-3-Clause OR GPL-2.0-only
-      choice: MIT
-  - package_id: "NPM::lodash.defaults:4.2.0"
-    license_choices:
-    - given: MIT OR BSD-3-Clause OR GPL-2.0-only
-      choice: MIT
-  - package_id: "NPM::lodash.isarguments:3.1.0"
-    license_choices:
-    - given: MIT OR BSD-3-Clause OR GPL-2.0-only
-      choice: MIT
-  - package_id: "NPM::type-fest:0.6.0"
-    license_choices:
-    - given: CC0-1.0 OR MIT
-      choice: MIT
-  - package_id: "NPM::type-fest:0.8.1"
-    license_choices:
-    - given: CC0-1.0 OR MIT
-      choice: MIT
-  - package_id: "NPM::type-fest:0.16.0"
-    license_choices:
-    - given: CC0-1.0 OR MIT
-      choice: MIT
-  - package_id: "NPM::type-fest:0.21.3"
-    license_choices:
-    - given: CC0-1.0 OR MIT
-      choice: MIT
+  repository_license_choices:
+  - given: CC0-1.0 OR MIT
+    choice: MIT
+  - given: GPL-2.0-only OR MIT
+    choice: MIT
+  - given: MIT OR BSD-3-Clause OR GPL-2.0-only
+    choice: MIT


### PR DESCRIPTION
There is no need to limit these choices to individual packages here, so condense them to repository choices that apply to all projects and their packages used in the repository. Also see [1].

[1]: https://oss-review-toolkit.org/ort/docs/configuration/ort-yml#license-choice-for-the-project