### PR TITLE
Do 346 writing spdx statements repeatedly

### DIFF
--- a/apps/clearance_ui/src/components/license_conclusions/ConclusionSPDX.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/ConclusionSPDX.tsx
@@ -27,7 +27,7 @@ const ConclusionSPDX = ({ value, setValue }: Props) => {
         <div className="flex">
             <Input
                 className="w-full rounded-md text-xs"
-                type="text"
+                name="spdx"
                 placeholder="Write your SPDX expression here..."
                 value={value}
                 onChange={handleInput}

--- a/apps/clearance_ui/src/components/path_exclusions/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/path_exclusions/ExclusionForm.tsx
@@ -19,6 +19,7 @@ import {
     FormLabel,
     FormMessage,
 } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
     Select,
@@ -124,9 +125,9 @@ const ExclusionForm = ({ purl, pattern, setOpen }: Props) => {
                             <FormItem>
                                 <FormLabel>Pattern</FormLabel>
                                 <FormControl>
-                                    <Textarea
-                                        className="text-xs"
-                                        placeholder="Pattern..."
+                                    <Input
+                                        className="!min-h-[40px] text-xs"
+                                        placeholder="Glob pattern matching to the path to be excluded..."
                                         {...field}
                                     />
                                 </FormControl>


### PR DESCRIPTION
This PR is a "fast fix" to the issue for not remembering the SPDX Expressions which the user has input earlier to the license conclusions form.  It utilizes the browser's native autosuggestion feature.  Note that as of today, only Firefox seems to remember more than one earlier input, while Microsoft Edge and Chrome seem to have an autosuggestion history of exactly one element.