### PR TITLE
Update spdx-expression-parse to our forked version

### DIFF
--- a/apps/clearance_ui/package.json
+++ b/apps/clearance_ui/package.json
@@ -64,7 +64,7 @@
     },
     "devDependencies": {
         "@playwright/test": "1.40.1",
-        "@testing-library/jest-dom": "6.1.5",
+        "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "14.1.2",
         "@types/js-yaml": "4.0.9",
         "@types/react": "18.2.42",

--- a/apps/clearance_ui/package.json
+++ b/apps/clearance_ui/package.json
@@ -55,7 +55,7 @@
         "react-copy-to-clipboard": "5.1.0",
         "react-hook-form": "7.48.2",
         "react-icons": "4.12.0",
-        "spdx-expression-parse": "4.0.0",
+        "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js",
         "tailwind-merge": "2.1.0",
         "tailwindcss-animate": "1.0.7",
         "validation-helpers": "*",

--- a/apps/clearance_ui/package.json
+++ b/apps/clearance_ui/package.json
@@ -55,12 +55,12 @@
         "react-copy-to-clipboard": "5.1.0",
         "react-hook-form": "7.48.2",
         "react-icons": "4.12.0",
-        "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js",
         "tailwind-merge": "2.1.0",
         "tailwindcss-animate": "1.0.7",
         "validation-helpers": "*",
         "zod": "3.22.4",
-        "zustand": "4.4.7"
+        "zustand": "4.4.7",
+        "common-helpers": "*"
     },
     "devDependencies": {
         "@playwright/test": "1.40.1",

--- a/apps/clearance_ui/src/components/license_conclusions/ConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/ConclusionForm.tsx
@@ -7,9 +7,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { ZodiosResponseByPath } from "@zodios/core";
 import axios from "axios";
+import { parseSPDX } from "common-helpers";
 import { Info } from "lucide-react";
 import { useForm } from "react-hook-form";
-import parse from "spdx-expression-parse";
 import { userAPI } from "validation-helpers";
 import { z } from "zod";
 import { userHooks } from "@/hooks/zodiosHooks";
@@ -43,7 +43,7 @@ const conclusionFormSchema = z.object({
         .refine(
             (value) => {
                 try {
-                    parse(value);
+                    parseSPDX(value);
                     return true;
                 } catch (e) {
                     return false;

--- a/apps/clearance_ui/tests/unit/spdxValidationTS.test.ts
+++ b/apps/clearance_ui/tests/unit/spdxValidationTS.test.ts
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 // SPDX-expression-parse unit tests
-import parse from "spdx-expression-parse";
+import { parseSPDX } from "common-helpers";
 
 describe("SPDX expression parse tests", () => {
     it("Accepts a single valid license", () => {
         const licenses = ["MIT", "GPL-2.0-only", "Apache-2.0"];
         for (const license of licenses) {
-            expect(parse(license)).toEqual({ license });
+            expect(parseSPDX(license)).toEqual({ license });
         }
     });
 
@@ -18,12 +18,12 @@ describe("SPDX expression parse tests", () => {
             "MIT OR GPL-2.0-only",
             "(MIT AND GPL-2.0-only) OR Apache-2.0",
         ];
-        expect(parse(expressions[0])).toEqual({
+        expect(parseSPDX(expressions[0])).toEqual({
             left: { license: "MIT" },
             conjunction: "or",
             right: { license: "GPL-2.0-only" },
         });
-        expect(parse(expressions[1])).toEqual({
+        expect(parseSPDX(expressions[1])).toEqual({
             left: {
                 left: { license: "MIT" },
                 conjunction: "and",
@@ -37,7 +37,7 @@ describe("SPDX expression parse tests", () => {
     it("Rejects an invalid license", () => {
         const licenses = ["BSD-2-Clause-FreeBSD", "GPL-2.0", "LGPL-2.0+"];
         for (const license of licenses) {
-            expect(() => parse(license)).toThrow();
+            expect(() => parseSPDX(license)).toThrow();
         }
     });
 
@@ -48,7 +48,7 @@ describe("SPDX expression parse tests", () => {
             "(MIT AND GPL-2.0-only",
         ];
         for (const expression of expressions) {
-            expect(() => parse(expression)).toThrow();
+            expect(() => parseSPDX(expression)).toThrow();
         }
     });
 });

--- a/apps/clearance_ui/tests/unit/spdxValidationTS.test.ts
+++ b/apps/clearance_ui/tests/unit/spdxValidationTS.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2023 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+// SPDX-expression-parse unit tests
+import parse from "spdx-expression-parse";
+
+describe("SPDX expression parse tests", () => {
+    it("Accepts a single valid license", () => {
+        const licenses = ["MIT", "GPL-2.0-only", "Apache-2.0"];
+        for (const license of licenses) {
+            expect(parse(license)).toEqual({ license });
+        }
+    });
+
+    it("Accepts a valid SPDX expression", () => {
+        const expressions = [
+            "MIT OR GPL-2.0-only",
+            "(MIT AND GPL-2.0-only) OR Apache-2.0",
+        ];
+        expect(parse(expressions[0])).toEqual({
+            left: { license: "MIT" },
+            conjunction: "or",
+            right: { license: "GPL-2.0-only" },
+        });
+        expect(parse(expressions[1])).toEqual({
+            left: {
+                left: { license: "MIT" },
+                conjunction: "and",
+                right: { license: "GPL-2.0-only" },
+            },
+            conjunction: "or",
+            right: { license: "Apache-2.0" },
+        });
+    });
+
+    it("Rejects an invalid license", () => {
+        const licenses = ["BSD-2-Clause-FreeBSD", "GPL-2.0", "LGPL-2.0+"];
+        for (const license of licenses) {
+            expect(() => parse(license)).toThrow();
+        }
+    });
+
+    it("Rejects an invalid SPDX expression", () => {
+        const expressions = [
+            "MIT OR",
+            "MIT AND GPL-2.0-only OR",
+            "(MIT AND GPL-2.0-only",
+        ];
+        for (const expression of expressions) {
+            expect(() => parse(expression)).toThrow();
+        }
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
             },
             "devDependencies": {
                 "@playwright/test": "1.40.1",
-                "@testing-library/jest-dom": "6.1.5",
+                "@testing-library/jest-dom": "5.16.5",
                 "@testing-library/react": "14.1.2",
                 "@types/js-yaml": "4.0.9",
                 "@types/react": "18.2.42",
@@ -140,6 +140,83 @@
                 "typescript": "5.3.3"
             }
         },
+        "apps/clearance_ui/node_modules/@testing-library/jest-dom": {
+            "version": "5.16.5",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
+            "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+            "dev": true,
+            "dependencies": {
+                "@adobe/css-tools": "^4.0.1",
+                "@babel/runtime": "^7.9.2",
+                "@types/testing-library__jest-dom": "^5.9.1",
+                "aria-query": "^5.0.0",
+                "chalk": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.5.6",
+                "lodash": "^4.17.15",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "apps/clearance_ui/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "apps/clearance_ui/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "apps/clearance_ui/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "apps/clearance_ui/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "apps/clearance_ui/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "apps/clearance_ui/node_modules/spdx-expression-parse": {
             "version": "4.0.0",
             "resolved": "git+ssh://git@github.com/doubleopen-project/spdx-expression-parse.js.git#b557759fdca47824230b648a7bd87590d03828ee",
@@ -147,6 +224,18 @@
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "apps/clearance_ui/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "apps/curation_front_end": {
@@ -6049,114 +6138,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@testing-library/jest-dom": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.5.tgz",
-            "integrity": "sha512-3y04JLW+EceVPy2Em3VwNr95dOKqA8DhR0RJHhHKDZNYXcVXnEK7WIrpj4eYU8SVt/qYZ2aRWt/WgQ+grNES8g==",
-            "dev": true,
-            "dependencies": {
-                "@adobe/css-tools": "^4.3.1",
-                "@babel/runtime": "^7.9.2",
-                "aria-query": "^5.0.0",
-                "chalk": "^3.0.0",
-                "css.escape": "^1.5.1",
-                "dom-accessibility-api": "^0.5.6",
-                "lodash": "^4.17.15",
-                "redent": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">=6",
-                "yarn": ">=1"
-            },
-            "peerDependencies": {
-                "@jest/globals": ">= 28",
-                "@types/jest": ">= 28",
-                "jest": ">= 28",
-                "vitest": ">= 0.32"
-            },
-            "peerDependenciesMeta": {
-                "@jest/globals": {
-                    "optional": true
-                },
-                "@types/jest": {
-                    "optional": true
-                },
-                "jest": {
-                    "optional": true
-                },
-                "vitest": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@testing-library/react": {
             "version": "14.1.2",
             "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
@@ -6429,6 +6410,48 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/jest": {
+            "version": "29.5.11",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
+            "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+            "dev": true,
+            "dependencies": {
+                "expect": "^29.0.0",
+                "pretty-format": "^29.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@types/jest/node_modules/pretty-format": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+            "dev": true
+        },
         "node_modules/@types/js-yaml": {
             "version": "4.0.9",
             "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -6666,6 +6689,15 @@
             "dependencies": {
                 "@types/express": "*",
                 "@types/serve-static": "*"
+            }
+        },
+        "node_modules/@types/testing-library__jest-dom": {
+            "version": "5.14.9",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
+            "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
+            "dev": true,
+            "dependencies": {
+                "@types/jest": "*"
             }
         },
         "node_modules/@types/throng": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
                 "react-copy-to-clipboard": "5.1.0",
                 "react-hook-form": "7.48.2",
                 "react-icons": "4.12.0",
-                "spdx-expression-parse": "4.0.0",
+                "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js",
                 "tailwind-merge": "2.1.0",
                 "tailwindcss-animate": "1.0.7",
                 "validation-helpers": "*",
@@ -138,6 +138,15 @@
                 "tailwindcss": "3.3.6",
                 "ts-jest": "29.1.1",
                 "typescript": "5.3.3"
+            }
+        },
+        "apps/clearance_ui/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "git+ssh://git@github.com/doubleopen-project/spdx-expression-parse.js.git#b557759fdca47824230b648a7bd87590d03828ee",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "apps/curation_front_end": {
@@ -19234,15 +19243,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
             "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
         },
         "node_modules/spdx-license-ids": {
             "version": "3.0.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
                 "react-copy-to-clipboard": "5.1.0",
                 "react-hook-form": "7.48.2",
                 "react-icons": "4.12.0",
-                "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js",
                 "tailwind-merge": "2.1.0",
                 "tailwindcss-animate": "1.0.7",
                 "validation-helpers": "*",
@@ -215,15 +214,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "apps/clearance_ui/node_modules/spdx-expression-parse": {
-            "version": "4.0.0",
-            "resolved": "git+ssh://git@github.com/doubleopen-project/spdx-expression-parse.js.git#b557759fdca47824230b648a7bd87590d03828ee",
-            "license": "MIT",
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
             }
         },
         "apps/clearance_ui/node_modules/supports-color": {
@@ -19276,6 +19266,15 @@
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
             "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
         },
+        "node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "git+ssh://git@github.com/doubleopen-project/spdx-expression-parse.js.git#b557759fdca47824230b648a7bd87590d03828ee",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
         "node_modules/spdx-license-ids": {
             "version": "3.0.16",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
@@ -21714,7 +21713,8 @@
         "packages/common-helpers": {
             "dependencies": {
                 "dotenv": "16.3.1",
-                "pako": "2.1.0"
+                "pako": "2.1.0",
+                "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js"
             },
             "devDependencies": {
                 "@types/chai": "4.3.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
                 "class-variance-authority": "0.7.0",
                 "clsx": "2.0.0",
                 "cmdk": "0.2.0",
+                "common-helpers": "*",
                 "generate-password": "1.7.1",
                 "js-yaml": "4.1.0",
                 "lucide-react": "0.294.0",
@@ -21720,6 +21721,7 @@
                 "@types/chai": "4.3.11",
                 "@types/mocha": "10.0.6",
                 "@types/pako": "2.0.3",
+                "@types/spdx-expression-parse": "^3.0.5",
                 "chai": "4.3.10",
                 "mocha": "10.2.0"
             }

--- a/packages/common-helpers/index.d.ts
+++ b/packages/common-helpers/index.d.ts
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+import parse from "spdx-expression-parse";
+
 declare const getCurrentDateTime: () => string;
 
-export { getCurrentDateTime };
+declare function parseSPDX(spdxString: string): parse.Info;
+
+export { getCurrentDateTime, parseSPDX };

--- a/packages/common-helpers/package.json
+++ b/packages/common-helpers/package.json
@@ -13,9 +13,10 @@
         "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js"
     },
     "devDependencies": {
-        "@types/pako": "2.0.3",
         "@types/chai": "4.3.11",
         "@types/mocha": "10.0.6",
+        "@types/pako": "2.0.3",
+        "@types/spdx-expression-parse": "^3.0.5",
         "chai": "4.3.10",
         "mocha": "10.2.0"
     }

--- a/packages/common-helpers/package.json
+++ b/packages/common-helpers/package.json
@@ -9,7 +9,8 @@
     },
     "dependencies": {
         "dotenv": "16.3.1",
-        "pako": "2.1.0"
+        "pako": "2.1.0",
+        "spdx-expression-parse": "github:doubleopen-project/spdx-expression-parse.js"
     },
     "devDependencies": {
         "@types/pako": "2.0.3",

--- a/packages/common-helpers/src/index.ts
+++ b/packages/common-helpers/src/index.ts
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: MIT
 
 export * from "./dateTimeHelper";
+export * from "./spdxHelper";

--- a/packages/common-helpers/src/spdxHelper.ts
+++ b/packages/common-helpers/src/spdxHelper.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2023 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+// This masks the implementation details of the chosen SPDX expression parser
+import parse from "spdx-expression-parse";
+
+export function parseSPDX(spdxString: string): parse.Info {
+    return parse(spdxString);
+}


### PR DESCRIPTION
This PR fixes the issue of accepting deprecated licenses as components of SPDX expressions.  The solution involves forking our own version from the [SPDX validation library](https://github.com/jslicense/spdx-expression-parse.js), as the original library always included also deprecated licenses to the list of valid licenses.