### PR TITLE
Use default variant for submit buttons

### DIFF
--- a/apps/clearance_ui/src/components/license_conclusions/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/BulkConclusionForm.tsx
@@ -392,7 +392,6 @@ const BulkConclusionForm = ({ purl, className, setOpen }: Props) => {
                         <Button
                             type="submit"
                             className="mt-2 rounded-md p-1 text-xs"
-                            variant={"outline"}
                         >
                             Add bulk conclusion
                         </Button>

--- a/apps/clearance_ui/src/components/license_conclusions/ConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/ConclusionForm.tsx
@@ -306,11 +306,7 @@ const ConclusionForm = ({
                                 </FormItem>
                             )}
                         />
-                        <Button
-                            type="submit"
-                            className="text-left text-xs"
-                            variant={"outline"}
-                        >
+                        <Button type="submit" className="text-left text-xs">
                             Submit
                         </Button>
                     </div>

--- a/apps/clearance_ui/src/components/path_exclusions/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/path_exclusions/ExclusionForm.tsx
@@ -259,7 +259,6 @@ const ExclusionForm = ({
                     )}
                     <div className="flex justify-end">
                         <Button
-                            variant="outline"
                             type="submit"
                             className="mt-2 rounded-md p-1 text-xs"
                         >

--- a/apps/clearance_ui/src/components/user_management/AddUserForm.tsx
+++ b/apps/clearance_ui/src/components/user_management/AddUserForm.tsx
@@ -254,11 +254,7 @@ const AddUserForm = ({ onNewUserCreated }: AddUserFormProps) => {
                     )}
                     {!isLoading && !isSuccess && (
                         <div className="flex flex-row">
-                            <Button
-                                className="mr-1 flex-1"
-                                type="submit"
-                                variant={"outline"}
-                            >
+                            <Button className="mr-1 flex-1" type="submit">
                                 Add user
                             </Button>
                             <Button

--- a/apps/clearance_ui/src/components/user_management/LoginForm.tsx
+++ b/apps/clearance_ui/src/components/user_management/LoginForm.tsx
@@ -156,12 +156,7 @@ const LoginForm = () => {
                             </FormItem>
                         )}
                     />
-                    <Button
-                        className="grow"
-                        type="submit"
-                        variant={"outline"}
-                        disabled={isLoading}
-                    >
+                    <Button className="grow" type="submit" disabled={isLoading}>
                         {isLoading && (
                             <>
                                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/apps/clearance_ui/src/components/user_management/TokenDialog.tsx
+++ b/apps/clearance_ui/src/components/user_management/TokenDialog.tsx
@@ -50,9 +50,7 @@ const TokenDialog = () => {
     return (
         <Dialog onOpenChange={toggleOpen}>
             <DialogTrigger asChild>
-                <Button variant="outline" onClick={onGenerateNewToken}>
-                    Generate new token
-                </Button>
+                <Button onClick={onGenerateNewToken}>Generate new token</Button>
             </DialogTrigger>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader>

--- a/apps/clearance_ui/src/components/user_management/UserDataForm.tsx
+++ b/apps/clearance_ui/src/components/user_management/UserDataForm.tsx
@@ -274,7 +274,7 @@ const UserDataForm = ({ user }: UserDataProps) => {
                                 isSuccess ? "!opacity-100" : undefined,
                             )}
                             type="submit"
-                            variant={isSuccess ? "success" : "outline"}
+                            variant={isSuccess ? "success" : "default"}
                             disabled={isLoading || isSuccess}
                         >
                             {isSuccess && <Check />}


### PR DESCRIPTION
This PR makes the confirmation/submit type of action buttons stand out, by changing them into a "default" variant, instead of "outline".