### PR TITLE
Do 475 decompose spdx license expressions

### DIFF
--- a/apps/clearance_ui/src/components/package_inspector/ComboBoxPackage.tsx
+++ b/apps/clearance_ui/src/components/package_inspector/ComboBoxPackage.tsx
@@ -111,9 +111,16 @@ const ComboBoxPackage = ({
                                                 : "opacity-0",
                                         )}
                                     />
-                                    <span className="w-11/12 text-xs">
-                                        {license.label}
-                                    </span>
+                                    {license.label.includes("AND") ||
+                                    license.label.includes("OR") ? (
+                                        <span className="w-11/12 text-xs text-red-600">
+                                            {license.label}
+                                        </span>
+                                    ) : (
+                                        <span className="w-11/12 text-xs">
+                                            {license.label}
+                                        </span>
+                                    )}
                                     <span
                                         className="ml-2 mt-1 flex h-2 w-2 items-center justify-center rounded-full"
                                         style={{

--- a/apps/clearance_ui/src/components/package_inspector/LicenseSelector.tsx
+++ b/apps/clearance_ui/src/components/package_inspector/LicenseSelector.tsx
@@ -27,17 +27,17 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-type ComboBoxPackageProps = {
+type LicenseSelectorProps = {
     data: Map<string, string>;
     filterString: string;
     className?: string;
 };
 
-const ComboBoxPackage = ({
+const LicenseSelector = ({
     data,
     filterString,
     className,
-}: ComboBoxPackageProps) => {
+}: LicenseSelectorProps) => {
     const [open, setOpen] = useState(false);
     const [value, setValue] = useQueryState(filterString, {
         parse: (query: string) => query.toLowerCase(),
@@ -158,4 +158,4 @@ const ComboBoxPackage = ({
     );
 };
 
-export default ComboBoxPackage;
+export default LicenseSelector;

--- a/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
+++ b/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
@@ -22,7 +22,7 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "@/components/ui/tooltip";
-import ComboBoxPackage from "@/components/package_inspector/ComboBoxPackage";
+import LicenseSelector from "@/components/package_inspector/LicenseSelector";
 import Node from "@/components/package_inspector/Node";
 import ExclusionDB from "@/components/path_exclusions/ExclusionDB";
 import ExclusionTools from "@/components/path_exclusions/ExclusionTools";
@@ -320,7 +320,7 @@ const PackageTree = ({ purl, path }: Props) => {
             </div>
 
             <div className="mt-2 flex flex-col items-center rounded-md border p-1 text-sm shadow-lg">
-                <ComboBoxPackage
+                <LicenseSelector
                     data={uniqueLicensesToColorMap}
                     filterString={"licenseFilter"}
                     className="mb-1 w-full"

--- a/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
+++ b/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
@@ -28,6 +28,7 @@ import ExclusionDB from "@/components/path_exclusions/ExclusionDB";
 import ExclusionTools from "@/components/path_exclusions/ExclusionTools";
 import PurlDetails from "@/components/PurlDetails";
 import { convertJsonToTree } from "@/helpers/convertJsonToTree";
+import { decomposeLicenses } from "@/helpers/decomposeLicenses";
 import { extractUniqueLicenses } from "@/helpers/extractUniqueLicenses";
 import { filterTreeDataByLicense } from "@/helpers/filterTreeDataByLicense";
 import { findNodeByPath } from "@/helpers/findNodeByPath";
@@ -99,7 +100,9 @@ const PackageTree = ({ purl, path }: Props) => {
     );
 
     let tree: TreeApi<TreeNode> | null | undefined;
-    const uniqueLicenses = extractUniqueLicenses(originalTreeData);
+    const uniqueLicenses = decomposeLicenses(
+        extractUniqueLicenses(originalTreeData),
+    );
     const uniqueLicensesToColorMap = new Map<string, string>();
 
     uniqueLicenses.forEach((license) => {

--- a/apps/clearance_ui/src/helpers/decomposeLicenses.ts
+++ b/apps/clearance_ui/src/helpers/decomposeLicenses.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { parseSPDX } from "common-helpers";
+import parse from "spdx-expression-parse";
 
 type SPDXExpression = {
     license?: string;
@@ -42,10 +43,13 @@ export function decomposeLicenses(spdxExpressions: Set<string>): Set<string> {
 
     // Process each SPDX expression and extract licenses
     spdxExpressions.forEach((spdxExpression) => {
-        console.log(`Processing ${spdxExpression}`);
-        const parsedInfo = parseSPDX(spdxExpression);
-        const licenses = extractLicenses(parsedInfo);
-        allLicenses.push(...licenses);
+        try {
+            const parsedInfo = parseSPDX(spdxExpression);
+            const licenses = extractLicenses(parsedInfo);
+            allLicenses.push(...licenses);
+        } catch (e) {
+            allLicenses.push("INVALID SPDX EXPRESSION: " + e);
+        }
     });
 
     // Deduplicate and sort the licenses alphabetically

--- a/apps/clearance_ui/src/helpers/decomposeLicenses.ts
+++ b/apps/clearance_ui/src/helpers/decomposeLicenses.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 import { parseSPDX } from "common-helpers";
-import parse from "spdx-expression-parse";
 
 type SPDXExpression = {
     license?: string;

--- a/apps/clearance_ui/src/helpers/decomposeLicenses.ts
+++ b/apps/clearance_ui/src/helpers/decomposeLicenses.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { parseSPDX } from "common-helpers";
+
+type SPDXExpression = {
+    license?: string;
+    exception?: string;
+    conjunction?: "and" | "or";
+    left?: SPDXExpression;
+    right?: SPDXExpression;
+};
+
+function extractLicenses(expression: SPDXExpression | undefined): string[] {
+    if (!expression) {
+        return [];
+    }
+    const licenses: string[] = [];
+
+    if (expression.license) {
+        if (expression.exception) {
+            licenses.push(`${expression.license} WITH ${expression.exception}`);
+        } else {
+            licenses.push(expression.license);
+        }
+    }
+    if (expression.left) {
+        const leftLicenses = extractLicenses(expression.left);
+        licenses.push(...leftLicenses);
+    }
+    if (expression.right) {
+        const rightLicenses = extractLicenses(expression.right);
+        licenses.push(...rightLicenses);
+    }
+
+    return licenses;
+}
+
+export function decomposeLicenses(spdxExpressions: Set<string>): Set<string> {
+    const allLicenses: string[] = [];
+
+    // Process each SPDX expression and extract licenses
+    spdxExpressions.forEach((spdxExpression) => {
+        console.log(`Processing ${spdxExpression}`);
+        const parsedInfo = parseSPDX(spdxExpression);
+        const licenses = extractLicenses(parsedInfo);
+        allLicenses.push(...licenses);
+    });
+
+    // Deduplicate and sort the licenses alphabetically
+    const uniqueLicenses = Array.from(new Set(allLicenses)).sort();
+
+    return new Set(uniqueLicenses);
+}

--- a/apps/clearance_ui/src/helpers/decomposeLicenses.ts
+++ b/apps/clearance_ui/src/helpers/decomposeLicenses.ts
@@ -48,7 +48,7 @@ export function decomposeLicenses(spdxExpressions: Set<string>): Set<string> {
             const licenses = extractLicenses(parsedInfo);
             allLicenses.push(...licenses);
         } catch (e) {
-            allLicenses.push("INVALID SPDX EXPRESSION: " + e);
+            allLicenses.push(spdxExpression);
         }
     });
 


### PR DESCRIPTION
The ORT Evaluator rules engine reports policy violations with either a single violating `licenseId`, or in format `licenseId WITH exceptionId`.

This PR improves linking from the ORT WebApp to Clearance UI by decomposing and deduplicating all ScanCode's **valid** high-level per-file SPDX license expressions into either single licenses or licenses with exceptions.  This way, when clicking a link to Clearance UI from WebApp, the UI opens in a defined state, with the violating license pre-selected to license filter.

[There is an open issue for ScanCode](https://github.com/nexB/scancode-toolkit/issues/2855) about reporting exceptions as stand-alone licenses, leading to **invalid** SPDX expressions such as `GPL-2.0-only AND Classpath-exception-2.0`, especially in notice files.  As these invalid expressions lead to SPDX parsing failure in Clearance UI, we leave invalid SPDX expressions as-is, and indicate their invalidity in the license list of the Main UI.  This is a preventive measure only, to survive invalid expressions, while waiting for ScanCode to get fixed.