### PR TITLE
Replace erroneous operators when saving scan results

### DIFF
--- a/apps/api/src/helpers/license_expression_helpers.ts
+++ b/apps/api/src/helpers/license_expression_helpers.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+export const replaceANDExceptionWithWITHException = (expression: string) => {
+    const regex = /AND\s+([\w-]*exception[\w-]*)/gi;
+
+    return expression.replace(regex, (match, p1) => `WITH ${p1}`);
+};

--- a/apps/api/tests/suites/helpers.spec.ts
+++ b/apps/api/tests/suites/helpers.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { assert } from "chai";
+import { replaceANDExceptionWithWITHException } from "../../src/helpers/license_expression_helpers";
 import { parsePurl } from "../../src/helpers/purl_helpers";
 
 export default function suite(): void {
@@ -48,5 +49,16 @@ export default function suite(): void {
         assert.strictEqual(parsedPurl.version, "1.5.2");
         assert.strictEqual(parsedPurl.qualifiers, undefined);
         assert.strictEqual(parsedPurl.subpath, null);
+    });
+
+    it("should replace AND exception with WITH exception", function () {
+        const expression =
+            "AFL-2.1 AND ANTLR-PD AND APSL-1.0 AND APSL-2.0 AND Apache-1.1 AND Apache-2.0 AND (Apache-2.0 AND Artistic-1.0 AND Artistic-1.0-Perl) AND BSD-2-Clause AND BSD-2-Clause-Views AND BSD-3-Clause AND BSD-4-Clause AND BSD-4-Clause-UC AND BSL-1.0 AND (CC-BY-2.5 AND CC-BY-3.0) AND (CC-BY-4.0 AND CC-BY-SA-3.0 AND CC-BY-SA-4.0) AND CDDL-1.0 AND CDDL-1.1 AND CPL-1.0 AND Classpath-exception-2.0 AND EPL-1.0 AND EPL-2.0 AND (FSFAP AND GPL-1.0-only) AND GPL-1.0-or-later AND GPL-2.0-only AND (GPL-2.0-only AND Classpath-exception-2.0) AND (GPL-2.0-or-later AND Classpath-exception-2.0 AND GPL-3.0-only) AND HPND AND ICU AND IJG AND ISC AND (JSON AND LGPL-2.0-only) AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND LGPL-3.0-or-later AND LPPL-1.3c AND Libpng AND Autoconf-exception-generic AND Bitstream-Vera AND LicenseRef-scancode-bsd-3-clause-no-change AND LicenseRef-scancode-bsd-simplified-darwin AND LicenseRef-scancode-freemarker AND LicenseRef-scancode-ietf AND LicenseRef-scancode-ietf-trust AND LicenseRef-scancode-iptc-2006 AND (LicenseRef-scancode-iso-8879 AND LicenseRef-scancode-jetty-ccla-1.1) AND (LicenseRef-scancode-mit-nagy AND LicenseRef-scancode-mit-old-style) AND (LicenseRef-scancode-mx4j AND LicenseRef-scancode-oasis-ws-security-spec AND LicenseRef-scancode-ogc) AND LicenseRef-scancode-protobuf AND (LicenseRef-scancode-red-hat-attribution AND LicenseRef-scancode-rsa-md4) AND (snprintf AND LicenseRef-scancode-sun-sdk-spec-1.1) AND SunPro AND LicenseRef-scancode-ubuntu-font-1.0 AND LicenseRef-scancode-unicode AND LicenseRef-scancode-unicode-mappings AND LicenseRef-scancode-ws-addressing-spec AND LicenseRef-scancode-ws-trust-specification AND LicenseRef-scancode-x11-lucent AND MIT AND (MIT-open-group AND MPL-1.0) AND (MPL-1.1 AND MPL-2.0) AND MS-PL AND NCSA AND NPL-1.1 AND (NTP AND Noweb) AND (OFL-1.1 AND OLDAP-2.8) AND (OpenSSL AND Python-2.0) AND (Ruby AND Unicode-DFS-2016) AND W3C AND W3C-19980720 AND X11 AND Zlib AND bzip2-1.0.6 AND curl";
+        const expectedExpression =
+            "AFL-2.1 AND ANTLR-PD AND APSL-1.0 AND APSL-2.0 AND Apache-1.1 AND Apache-2.0 AND (Apache-2.0 AND Artistic-1.0 AND Artistic-1.0-Perl) AND BSD-2-Clause AND BSD-2-Clause-Views AND BSD-3-Clause AND BSD-4-Clause AND BSD-4-Clause-UC AND BSL-1.0 AND (CC-BY-2.5 AND CC-BY-3.0) AND (CC-BY-4.0 AND CC-BY-SA-3.0 AND CC-BY-SA-4.0) AND CDDL-1.0 AND CDDL-1.1 AND CPL-1.0 WITH Classpath-exception-2.0 AND EPL-1.0 AND EPL-2.0 AND (FSFAP AND GPL-1.0-only) AND GPL-1.0-or-later AND GPL-2.0-only AND (GPL-2.0-only WITH Classpath-exception-2.0) AND (GPL-2.0-or-later WITH Classpath-exception-2.0 AND GPL-3.0-only) AND HPND AND ICU AND IJG AND ISC AND (JSON AND LGPL-2.0-only) AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND LGPL-3.0-or-later AND LPPL-1.3c AND Libpng WITH Autoconf-exception-generic AND Bitstream-Vera AND LicenseRef-scancode-bsd-3-clause-no-change AND LicenseRef-scancode-bsd-simplified-darwin AND LicenseRef-scancode-freemarker AND LicenseRef-scancode-ietf AND LicenseRef-scancode-ietf-trust AND LicenseRef-scancode-iptc-2006 AND (LicenseRef-scancode-iso-8879 AND LicenseRef-scancode-jetty-ccla-1.1) AND (LicenseRef-scancode-mit-nagy AND LicenseRef-scancode-mit-old-style) AND (LicenseRef-scancode-mx4j AND LicenseRef-scancode-oasis-ws-security-spec AND LicenseRef-scancode-ogc) AND LicenseRef-scancode-protobuf AND (LicenseRef-scancode-red-hat-attribution AND LicenseRef-scancode-rsa-md4) AND (snprintf AND LicenseRef-scancode-sun-sdk-spec-1.1) AND SunPro AND LicenseRef-scancode-ubuntu-font-1.0 AND LicenseRef-scancode-unicode AND LicenseRef-scancode-unicode-mappings AND LicenseRef-scancode-ws-addressing-spec AND LicenseRef-scancode-ws-trust-specification AND LicenseRef-scancode-x11-lucent AND MIT AND (MIT-open-group AND MPL-1.0) AND (MPL-1.1 AND MPL-2.0) AND MS-PL AND NCSA AND NPL-1.1 AND (NTP AND Noweb) AND (OFL-1.1 AND OLDAP-2.8) AND (OpenSSL AND Python-2.0) AND (Ruby AND Unicode-DFS-2016) AND W3C AND W3C-19980720 AND X11 AND Zlib AND bzip2-1.0.6 AND curl";
+
+        const result = replaceANDExceptionWithWITHException(expression);
+
+        assert.strictEqual(result, expectedExpression);
     });
 }


### PR DESCRIPTION
This PR fixes the issue with license finding SPDX expressions containing the "AND" operator instead of "WITH" before exceptions