### PR TITLE
Do 524 text wrap in clearance library table

### DIFF
--- a/apps/clearance_ui/src/components/bulk_conclusion_table/columns.tsx
+++ b/apps/clearance_ui/src/components/bulk_conclusion_table/columns.tsx
@@ -172,6 +172,9 @@ export const columns = (user: User): ColumnDef<BulkConclusion>[] => {
                     </Button>
                 );
             },
+            cell: ({ row }) => (
+                <div className="break-all">{row.original.pattern}</div>
+            ),
         },
         {
             accessorKey: "licenseExpressionSPDX",

--- a/apps/clearance_ui/src/components/license_conclusions/ConclusionDB.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/ConclusionDB.tsx
@@ -203,7 +203,9 @@ const ConclusionDB = ({
                                                 <span className="mr-1 font-bold">
                                                     Context PURL:
                                                 </span>
-                                                {d.contextPurl}
+                                                <div className="break-all">
+                                                    {d.contextPurl}
+                                                </div>
                                             </div>
 
                                             {/* Comment */}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "dev:api": "turbo run dev --no-cache --continue --no-daemon --filter=api",
         "dev:cui": "turbo run dev --no-cache --continue --no-daemon --filter=clearance_ui",
         "dev:scanner_agent": "turbo run dev --no-cache --continue --no-daemon --filter=scanner-agent",
-        "dev:prod": "turbo run dev:prod --no-cache --continue --no-daemon --concurrency=12",
+        "dev:prod": "turbo run dev:prod --no-cache --continue --no-daemon --concurrency=13",
         "lint": "turbo run lint",
         "lint:api": "turbo run lint --filter=api",
         "lint:cui": "turbo run lint --filter=clearance_ui",


### PR DESCRIPTION
This PR fixes the overflowing bulk conclusion table in the Clearance Library.  Also resolves DO-518 (breaking the layout of the license conclusion list in the Main UI), which was earlier cancelled due to upcoming refactor.  This is to help the people doing currently clearance work, while awaiting for the refactor.