### PR TITLE
Do 531 show package name and filename in navbar

### DIFF
--- a/apps/clearance_ui/src/components/PurlDetails.tsx
+++ b/apps/clearance_ui/src/components/PurlDetails.tsx
@@ -13,6 +13,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import CopyToClipboard from "@/components/CopyToClipboard";
 import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
+import { Label } from "./ui/label";
 
 type Props = {
     purl: string;
@@ -34,9 +35,9 @@ const PurlDetails = ({ purl }: Props) => {
             <Accordion type="single" collapsible>
                 <AccordionItem value="item-1">
                     <AccordionTrigger>
-                        <Badge className="break-all rounded-md px-1">
+                        <Label className="break-all px-1 text-xs">
                             {mainPurl}
-                        </Badge>
+                        </Label>
                     </AccordionTrigger>
 
                     <AccordionContent className="text-xs">

--- a/apps/clearance_ui/src/components/PurlDetails.tsx
+++ b/apps/clearance_ui/src/components/PurlDetails.tsx
@@ -10,10 +10,9 @@ import {
     AccordionItem,
     AccordionTrigger,
 } from "@/components/ui/accordion";
-import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
 import CopyToClipboard from "@/components/CopyToClipboard";
 import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
-import { Label } from "./ui/label";
 
 type Props = {
     purl: string;

--- a/apps/clearance_ui/src/components/file_inspector/CodeInspector.tsx
+++ b/apps/clearance_ui/src/components/file_inspector/CodeInspector.tsx
@@ -5,10 +5,6 @@
 import React, { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { userHooks } from "@/hooks/zodiosHooks";
-import { Badge } from "@/components/ui/badge";
-import { Label } from "@/components/ui/label";
-import { Separator } from "@/components/ui/separator";
-import CopyToClipboard from "@/components/CopyToClipboard";
 import CodeEditor from "@/components/file_inspector/CodeEditor";
 import { toPathPath, toPathPurl } from "@/helpers/pathParamHelpers";
 
@@ -62,14 +58,6 @@ const CodeInspector = ({ path, purl }: CodeInspectorProps) => {
 
     return (
         <div className="flex h-full flex-col">
-            <div className="mb-1 flex-row items-center p-1">
-                <Label className="clearance-label">File: </Label>
-                <Badge className="rounded-md">{path}</Badge>
-                <CopyToClipboard copyText={path} />
-            </div>
-
-            <Separator className="mb-2" />
-
             <div className="flex flex-1 items-center justify-center overflow-auto">
                 {(isLoading || lfIsLoading) && (
                     <div className="flex h-full items-center justify-center">

--- a/apps/clearance_ui/src/components/navigation/Navbar.tsx
+++ b/apps/clearance_ui/src/components/navigation/Navbar.tsx
@@ -2,16 +2,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useEffect } from "react";
+import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
+import { Label } from "@/components/ui/label";
 import CopyToClipboard from "@/components/CopyToClipboard";
 import { ModeToggle } from "@/components/ModeToggle";
+import SideMenu from "@/components/navigation/SideMenu";
+import UserMenuItem from "@/components/navigation/UserMenuItem";
 import PurlDetails from "@/components/PurlDetails";
-import { Label } from "../ui/label";
-import SideMenu from "./SideMenu";
-import UserMenuItem from "./UserMenuItem";
 
 const Navbar = () => {
     const router = useRouter();

--- a/apps/clearance_ui/src/components/navigation/Navbar.tsx
+++ b/apps/clearance_ui/src/components/navigation/Navbar.tsx
@@ -6,8 +6,10 @@ import React, { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
+import CopyToClipboard from "@/components/CopyToClipboard";
 import { ModeToggle } from "@/components/ModeToggle";
 import PurlDetails from "@/components/PurlDetails";
+import { Label } from "../ui/label";
 import SideMenu from "./SideMenu";
 import UserMenuItem from "./UserMenuItem";
 
@@ -17,10 +19,6 @@ const Navbar = () => {
 
     const { purl, path } = router.query;
 
-    useEffect(() => {
-        console.log("purl=", purl, "path=", path);
-    }, [purl, path]);
-
     return (
         <div className="overflow-none flex flex-row items-center justify-between border-b-[1px] py-2">
             <div className="flex items-center justify-start">
@@ -29,9 +27,19 @@ const Navbar = () => {
                     <span className="logo">doubleOpen</span>
                     <span className="logo logo-brackets">()</span>
                 </Link>
+                {purl && <PurlDetails purl={purl as string} />}
+                {path && (
+                    <>
+                        <Label className="pl-1 pr-2 text-lg font-semibold text-[#FF3366]">
+                            /
+                        </Label>
+                        <div className="flex-row items-center">
+                            <Label className="break-all text-xs">{path}</Label>
+                            <CopyToClipboard copyText={path as string} />
+                        </div>
+                    </>
+                )}
             </div>
-            {/* Insert package and file path here */}
-            {purl && <PurlDetails purl={purl as string} />}
             <div>
                 <UserMenuItem user={user} className="mr-1" />
                 <ModeToggle className="mr-1" />

--- a/apps/clearance_ui/src/components/navigation/Navbar.tsx
+++ b/apps/clearance_ui/src/components/navigation/Navbar.tsx
@@ -1,87 +1,37 @@
-// SPDX-FileCopyrightText: 2023 HH Partners
+// SPDX-FileCopyrightText: 2024 Double Open Oy
 //
 // SPDX-License-Identifier: MIT
 
-import React from "react";
+import React, { useEffect } from "react";
 import Link from "next/link";
-import { AiOutlineEye } from "react-icons/ai";
-import { IoMenuSharp } from "react-icons/io5";
-import { LuFileStack } from "react-icons/lu";
+import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
-import { Button } from "@/components/ui/button";
-import {
-    Sheet,
-    SheetClose,
-    SheetContent,
-    SheetDescription,
-    SheetHeader,
-    SheetTitle,
-    SheetTrigger,
-} from "@/components/ui/sheet";
 import { ModeToggle } from "@/components/ModeToggle";
+import PurlDetails from "@/components/PurlDetails";
+import SideMenu from "./SideMenu";
 import UserMenuItem from "./UserMenuItem";
 
 const Navbar = () => {
+    const router = useRouter();
     const user = useUser();
+
+    const { purl, path } = router.query;
+
+    useEffect(() => {
+        console.log("purl=", purl, "path=", path);
+    }, [purl, path]);
+
     return (
         <div className="overflow-none flex flex-row items-center justify-between border-b-[1px] py-2">
             <div className="flex items-center justify-start">
-                <Sheet>
-                    <SheetTrigger asChild>
-                        <Button variant="outline" size="sm" className="ml-2">
-                            <IoMenuSharp size="20px" color="gray" />
-                        </Button>
-                    </SheetTrigger>
-                    <SheetContent side="left">
-                        <SheetHeader>
-                            <SheetTitle>Pages</SheetTitle>
-                            <SheetDescription>
-                                Additional pages that help in the clearance
-                                work. This includes libraries, which list all
-                                the packages and clearances available in the
-                                database.
-                            </SheetDescription>
-                        </SheetHeader>
-                        {user && (
-                            <div className="grid gap-4 py-4">
-                                <SheetClose asChild>
-                                    <Link
-                                        href="/packages"
-                                        className="inline-block rounded-lg px-2 py-1 text-sm hover:bg-gray-100 hover:text-gray-900"
-                                    >
-                                        <div className="flex items-center">
-                                            <LuFileStack
-                                                size="20px"
-                                                className="mr-2"
-                                            />
-                                            Package Library
-                                        </div>
-                                    </Link>
-                                </SheetClose>
-                                <SheetClose asChild>
-                                    <Link
-                                        href="/clearances"
-                                        className="inline-block rounded-lg px-2 py-1 text-sm hover:bg-gray-100 hover:text-gray-900"
-                                    >
-                                        <div className="flex items-center">
-                                            <AiOutlineEye
-                                                size="20px"
-                                                className="mr-2"
-                                            />
-                                            Clearance Library
-                                        </div>
-                                    </Link>
-                                </SheetClose>
-                            </div>
-                        )}
-                    </SheetContent>
-                </Sheet>
+                <SideMenu />
                 <Link href="/" className="pl-2 pr-4">
                     <span className="logo">doubleOpen</span>
                     <span className="logo logo-brackets">()</span>
                 </Link>
             </div>
             {/* Insert package and file path here */}
+            {purl && <PurlDetails purl={purl as string} />}
             <div>
                 <UserMenuItem user={user} className="mr-1" />
                 <ModeToggle className="mr-1" />

--- a/apps/clearance_ui/src/components/navigation/SideMenu.tsx
+++ b/apps/clearance_ui/src/components/navigation/SideMenu.tsx
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import React from "react";
+import Link from "next/link";
+import { AiOutlineEye } from "react-icons/ai";
+import { IoMenuSharp } from "react-icons/io5";
+import { LuFileStack } from "react-icons/lu";
+import { useUser } from "@/hooks/useUser";
+import { Button } from "@/components/ui/button";
+import {
+    Sheet,
+    SheetClose,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+} from "@/components/ui/sheet";
+
+const SideMenu = () => {
+    const user = useUser();
+
+    return (
+        <Sheet>
+            <SheetTrigger asChild>
+                <Button variant="outline" size="sm" className="ml-2">
+                    <IoMenuSharp size="20px" color="gray" />
+                </Button>
+            </SheetTrigger>
+            <SheetContent side="left">
+                <SheetHeader>
+                    <SheetTitle>Pages</SheetTitle>
+                    <SheetDescription>
+                        Additional pages that help in the clearance work. This
+                        includes libraries, which list all the packages and
+                        clearances available in the database.
+                    </SheetDescription>
+                </SheetHeader>
+                {user && (
+                    <div className="grid gap-4 py-4">
+                        <SheetClose asChild>
+                            <Link
+                                href="/packages"
+                                className="inline-block rounded-lg px-2 py-1 text-sm hover:bg-gray-100 hover:text-gray-900"
+                            >
+                                <div className="flex items-center">
+                                    <LuFileStack size="20px" className="mr-2" />
+                                    Package Library
+                                </div>
+                            </Link>
+                        </SheetClose>
+                        <SheetClose asChild>
+                            <Link
+                                href="/clearances"
+                                className="inline-block rounded-lg px-2 py-1 text-sm hover:bg-gray-100 hover:text-gray-900"
+                            >
+                                <div className="flex items-center">
+                                    <AiOutlineEye
+                                        size="20px"
+                                        className="mr-2"
+                                    />
+                                    Clearance Library
+                                </div>
+                            </Link>
+                        </SheetClose>
+                    </div>
+                )}
+            </SheetContent>
+        </Sheet>
+    );
+};
+
+export default SideMenu;

--- a/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
+++ b/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
@@ -14,7 +14,6 @@ import { Tree, TreeApi } from "react-arborist";
 import { userHooks } from "@/hooks/zodiosHooks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Toggle } from "@/components/ui/toggle";
 import {
@@ -27,7 +26,6 @@ import LicenseSelector from "@/components/package_inspector/LicenseSelector";
 import Node from "@/components/package_inspector/Node";
 import ExclusionDB from "@/components/path_exclusions/ExclusionDB";
 import ExclusionTools from "@/components/path_exclusions/ExclusionTools";
-import PurlDetails from "@/components/PurlDetails";
 import { convertJsonToTree } from "@/helpers/convertJsonToTree";
 import { decomposeLicenses } from "@/helpers/decomposeLicenses";
 import { extractUniqueLicenses } from "@/helpers/extractUniqueLicenses";
@@ -194,11 +192,6 @@ const PackageTree = ({ purl, path }: Props) => {
 
     return (
         <div className="flex h-full flex-col">
-            <div className="mb-2 flex-row">
-                <Label className="clearance-label">Package: </Label>
-                <PurlDetails purl={purl} />
-            </div>
-
             <div className="mb-3 flex items-center text-sm">
                 <Input
                     className="w-full rounded-md text-xs"


### PR DESCRIPTION
In this PR, we remove the clean PURL and filepath from the Main UI and show them in the navigation bar.  Clean PURL is at this stage still being shown as an accordion component, and by clicking it, you can see details of the package as before.  Later on, we will probably show this package information in its own tab in the clearance toolbar and simplify the view in the navigation bar.