### PR TITLE
Do 547 implement details tab in clearance toolbar

### DIFF
--- a/apps/clearance_ui/src/components/ClearanceToolbar.tsx
+++ b/apps/clearance_ui/src/components/ClearanceToolbar.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { GoInfo } from "react-icons/go";
 import { LuFileStack, LuFolderTree } from "react-icons/lu";
 import { TbFoldersOff } from "react-icons/tb";
 import { TfiPencil } from "react-icons/tfi";
@@ -20,6 +21,7 @@ const ClearanceToolbar = () => {
 
     return (
         <div className="pl-2 pt-1">
+            {/* Inspect package and its tree */}
             <Link
                 href={`/packages/${encodeURIComponent(purl)}${
                     path ? `/tree/${encodeURIComponent(path)}` : ""
@@ -37,6 +39,24 @@ const ClearanceToolbar = () => {
                     Inspect
                 </div>
             </Link>
+
+            {/* Package details */}
+            <Link
+                href={`/packages/${encodeURIComponent(purl)}/details`}
+                className={cn(
+                    router.pathname === "/packages/[purl]/details"
+                        ? "border-b-4 border-[#ff3366] font-semibold"
+                        : "",
+                    "inline-block rounded-sm px-2 py-1 text-xs hover:bg-gray-100 hover:text-gray-900",
+                )}
+            >
+                <div className="flex items-center">
+                    <GoInfo className="mr-1" />
+                    Package Info
+                </div>
+            </Link>
+
+            {/* License conclusions */}
             <Link
                 href={`/packages/${encodeURIComponent(
                     purl,
@@ -53,6 +73,8 @@ const ClearanceToolbar = () => {
                     License Conclusions
                 </div>
             </Link>
+
+            {/* Bulk conclusions */}
             <Link
                 href={`/packages/${encodeURIComponent(purl)}/bulk_conclusions`}
                 className={cn(
@@ -67,6 +89,8 @@ const ClearanceToolbar = () => {
                     Bulk Conclusions
                 </div>
             </Link>
+
+            {/* Path exclusions */}
             <Link
                 href={`/packages/${encodeURIComponent(purl)}/path_exclusions`}
                 className={cn(

--- a/apps/clearance_ui/src/components/navigation/Navbar.tsx
+++ b/apps/clearance_ui/src/components/navigation/Navbar.tsx
@@ -5,19 +5,39 @@
 import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { PackageURL } from "packageurl-js";
 import { useUser } from "@/hooks/useUser";
 import { Label } from "@/components/ui/label";
 import CopyToClipboard from "@/components/CopyToClipboard";
 import { ModeToggle } from "@/components/ModeToggle";
 import SideMenu from "@/components/navigation/SideMenu";
 import UserMenuItem from "@/components/navigation/UserMenuItem";
-import PurlDetails from "@/components/PurlDetails";
+import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
 
 const Navbar = () => {
     const router = useRouter();
     const user = useUser();
 
     const { purl, path } = router.query;
+
+    if (!purl) {
+        return <div>Loading...</div>;
+    }
+    if (typeof purl !== "string") {
+        return <div>Invalid purl</div>;
+    }
+
+    // purl exists and is of correct type, so we can continue
+
+    const parsedPurl = parsePurlAndQualifiers(purl);
+    const mainPurl = new PackageURL(
+        parsedPurl.type,
+        parsedPurl.namespace,
+        parsedPurl.name,
+        parsedPurl.version,
+        null,
+        null,
+    ).toString();
 
     return (
         <div className="overflow-none flex flex-row items-center justify-between border-b-[1px] py-2">
@@ -27,7 +47,12 @@ const Navbar = () => {
                     <span className="logo">doubleOpen</span>
                     <span className="logo logo-brackets">()</span>
                 </Link>
-                {purl && <PurlDetails purl={purl as string} />}
+                {purl && (
+                    <div className="flex-row items-center">
+                        <Label className="break-all text-xs">{mainPurl}</Label>
+                        <CopyToClipboard copyText={mainPurl} />
+                    </div>
+                )}
                 {path && (
                     <>
                         <Label className="pl-1 pr-2 text-lg font-semibold text-[#FF3366]">

--- a/apps/clearance_ui/src/pages/packages/[purl]/bulk_conclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/bulk_conclusions.tsx
@@ -8,7 +8,15 @@ import ClearanceToolbar from "@/components/ClearanceToolbar";
 
 const PackageBulkConclusions = () => {
     const router = useRouter();
-    const purl = router.query.purl as string;
+    const purl = router.query.purl;
+
+    if (!purl) {
+        return <div>Loading...</div>;
+    }
+    if (typeof purl !== "string") {
+        return <div>Invalid purl</div>;
+    }
+
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -3,15 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 import React from "react";
-import { useRouter } from "next/router";
 import { PackageURL } from "packageurl-js";
-import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import useMainUiStore from "@/store/mainui.store";
 import ClearanceToolbar from "@/components/ClearanceToolbar";
 import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
 
 const Details = () => {
-    const router = useRouter();
-    const purl = router.query.purl as string;
+    const purl = useMainUiStore((state) => state.purl);
+
     const parsedPurl = parsePurlAndQualifiers(purl);
     const mainPurl = new PackageURL(
         parsedPurl.type,
@@ -21,62 +20,81 @@ const Details = () => {
         null,
         null,
     ).toString();
+
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />
             <div className="flex-1 border p-2">
-                <h3 className="font-semibold">Package Information</h3>
-
-                <Table className="mt-2 w-fit border p-2">
-                    <TableBody>
-                        <TableRow>
-                            <TableCell className="text-right font-semibold">
+                <div className="px-4 sm:px-0">
+                    <h3 className="font-semibold">Package Information</h3>
+                    <p className="mt-1 max-w-2xl text-sm">
+                        Details about package and its provenance.
+                    </p>
+                </div>
+                <div className="mt-6 rounded-lg border p-2">
+                    <dl className="">
+                        <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                            <dt className="text-right text-sm font-semibold leading-6">
                                 Name:
-                            </TableCell>
-                            <TableCell>{parsedPurl.name}</TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell className="text-right font-semibold">
+                            </dt>
+                            <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                {parsedPurl.name}
+                            </dd>
+                        </div>
+                        <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                            <dt className="text-right text-sm font-semibold leading-6">
                                 Version:
-                            </TableCell>
-                            <TableCell>{parsedPurl.version}</TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell className="text-right font-semibold">
+                            </dt>
+                            <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                {parsedPurl.version}
+                            </dd>
+                        </div>
+                        <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                            <dt className="text-right text-sm font-semibold leading-6">
                                 Type:
-                            </TableCell>
-                            <TableCell>{parsedPurl.type}</TableCell>
-                        </TableRow>
+                            </dt>
+                            <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                {parsedPurl.type}
+                            </dd>
+                        </div>
                         {parsedPurl.namespace && (
-                            <TableRow>
-                                <TableCell className="text-right font-semibold">
+                            <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                                <dt className="text-right text-sm font-semibold leading-6">
                                     Namespace:
-                                </TableCell>
-                                <TableCell>{parsedPurl.namespace}</TableCell>
-                            </TableRow>
+                                </dt>
+                                <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                    {parsedPurl.namespace}
+                                </dd>
+                            </div>
                         )}
                         {parsedPurl.subpath && (
-                            <TableRow>
-                                <TableCell className="text-right font-semibold">
+                            <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                                <dt className="text-right text-sm font-semibold leading-6">
                                     Subpath:
-                                </TableCell>
-                                <TableCell>{parsedPurl.subpath}</TableCell>
-                            </TableRow>
+                                </dt>
+                                <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                    {parsedPurl.subpath}
+                                </dd>
+                            </div>
                         )}
-                        <TableRow>
-                            <TableCell className="text-right font-semibold">
+                        <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                            <dt className="text-right text-sm font-semibold leading-6">
                                 Clean PURL:
-                            </TableCell>
-                            <TableCell>{mainPurl}</TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell className="text-right font-semibold">
+                            </dt>
+                            <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                {mainPurl}
+                            </dd>
+                        </div>
+                        <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                            <dt className="text-right text-sm font-semibold leading-6">
                                 Full PURL:
-                            </TableCell>
-                            <TableCell>{purl}</TableCell>
-                        </TableRow>
-                    </TableBody>
-                </Table>
+                            </dt>
+                            <dd className="mt-1 break-all text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                {purl}
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
             </div>
         </div>
     );

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -4,42 +4,79 @@
 
 import React from "react";
 import { useRouter } from "next/router";
-import { Label } from "@/components/ui/label";
-import {
-    Table,
-    TableBody,
-    TableCaption,
-    TableCell,
-    TableRow,
-} from "@/components/ui/table";
+import { PackageURL } from "packageurl-js";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import ClearanceToolbar from "@/components/ClearanceToolbar";
+import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
 
 const Details = () => {
     const router = useRouter();
     const purl = router.query.purl as string;
+    const parsedPurl = parsePurlAndQualifiers(purl);
+    const mainPurl = new PackageURL(
+        parsedPurl.type,
+        parsedPurl.namespace,
+        parsedPurl.name,
+        parsedPurl.version,
+        null,
+        null,
+    ).toString();
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />
             <div className="flex-1 border p-2">
-                <Label className="font-semibold">Package Information</Label>
-                <div className="rounded-lg border p-2">
-                    <Table>
-                        <TableBody>
+                <h3 className="font-semibold">Package Information</h3>
+
+                <Table className="mt-2 w-fit border p-2">
+                    <TableBody>
+                        <TableRow>
+                            <TableCell className="text-right font-semibold">
+                                Name:
+                            </TableCell>
+                            <TableCell>{parsedPurl.name}</TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="text-right font-semibold">
+                                Version:
+                            </TableCell>
+                            <TableCell>{parsedPurl.version}</TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="text-right font-semibold">
+                                Type:
+                            </TableCell>
+                            <TableCell>{parsedPurl.type}</TableCell>
+                        </TableRow>
+                        {parsedPurl.namespace && (
                             <TableRow>
-                                <TableCell className="font-semibold">
-                                    Name
+                                <TableCell className="text-right font-semibold">
+                                    Namespace:
                                 </TableCell>
-                                <TableCell>dos-monorepo</TableCell>
+                                <TableCell>{parsedPurl.namespace}</TableCell>
                             </TableRow>
+                        )}
+                        {parsedPurl.subpath && (
                             <TableRow>
-                                <TableCell className="font-semibold">
-                                    Version
+                                <TableCell className="text-right font-semibold">
+                                    Subpath:
                                 </TableCell>
-                                <TableCell>0.0.0</TableCell>
+                                <TableCell>{parsedPurl.subpath}</TableCell>
                             </TableRow>
-                        </TableBody>
-                    </Table>
-                </div>
+                        )}
+                        <TableRow>
+                            <TableCell className="text-right font-semibold">
+                                Clean PURL:
+                            </TableCell>
+                            <TableCell>{mainPurl}</TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="text-right font-semibold">
+                                Full PURL:
+                            </TableCell>
+                            <TableCell>{purl}</TableCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
             </div>
         </div>
     );

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import React from "react";
+import { useRouter } from "next/router";
+import { Label } from "@/components/ui/label";
+import {
+    Table,
+    TableBody,
+    TableCaption,
+    TableCell,
+    TableRow,
+} from "@/components/ui/table";
+import ClearanceToolbar from "@/components/ClearanceToolbar";
+
+const Details = () => {
+    const router = useRouter();
+    const purl = router.query.purl as string;
+    return (
+        <div className="flex h-full flex-col">
+            <ClearanceToolbar />
+            <div className="flex-1 border p-2">
+                <Label className="font-semibold">Package Information</Label>
+                <div className="rounded-lg border p-2">
+                    <Table>
+                        <TableBody>
+                            <TableRow>
+                                <TableCell className="font-semibold">
+                                    Name
+                                </TableCell>
+                                <TableCell>dos-monorepo</TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableCell className="font-semibold">
+                                    Version
+                                </TableCell>
+                                <TableCell>0.0.0</TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Details;

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -3,14 +3,21 @@
 // SPDX-License-Identifier: MIT
 
 import React from "react";
+import { useRouter } from "next/router";
 import { PackageURL } from "packageurl-js";
-import useMainUiStore from "@/store/mainui.store";
 import ClearanceToolbar from "@/components/ClearanceToolbar";
 import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
 
 const Details = () => {
-    const purl = useMainUiStore((state) => state.purl);
+    const router = useRouter();
+    const purl = router.query.purl;
 
+    if (!purl) {
+        return <div>Loading...</div>;
+    }
+    if (typeof purl !== "string") {
+        return <div>Invalid purl</div>;
+    }
     const parsedPurl = parsePurlAndQualifiers(purl);
     const mainPurl = new PackageURL(
         parsedPurl.type,

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -18,6 +18,9 @@ const Details = () => {
     if (typeof purl !== "string") {
         return <div>Invalid purl</div>;
     }
+
+    // purl exists and is of correct type, so we can continue
+
     const parsedPurl = parsePurlAndQualifiers(purl);
     const mainPurl = new PackageURL(
         parsedPurl.type,
@@ -27,24 +30,29 @@ const Details = () => {
         null,
         null,
     ).toString();
+    const provenanceType = parsedPurl.qualifiers?.vcs_type
+        ? "Repository Provenance"
+        : parsedPurl.qualifiers?.download_url
+          ? "Artefact Provenance"
+          : "Unknown";
 
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />
             <div className="flex-1 border p-2">
                 <div className="px-4 sm:px-0">
-                    <h3 className="font-semibold">Package Information</h3>
+                    <h3 className="mt-2 font-semibold">Package Information</h3>
                     <p className="mt-1 max-w-2xl text-sm">
                         Details about package and its provenance.
                     </p>
                 </div>
-                <div className="mt-6 rounded-lg border p-2">
-                    <dl className="">
+                <div className="mt-4 rounded-lg border p-2">
+                    <dl>
                         <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
                             <dt className="text-right text-sm font-semibold leading-6">
                                 Name:
                             </dt>
-                            <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                            <dd className="mt-1 text-sm font-bold leading-6 sm:col-span-2 sm:mt-0">
                                 {parsedPurl.name}
                             </dd>
                         </div>
@@ -98,6 +106,31 @@ const Details = () => {
                             </dt>
                             <dd className="mt-1 break-all text-sm leading-6 sm:col-span-2 sm:mt-0">
                                 {purl}
+                            </dd>
+                        </div>
+                        {parsedPurl.qualifiers &&
+                            Object.entries(parsedPurl.qualifiers).map(
+                                ([key, value]) => (
+                                    <div
+                                        className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0"
+                                        key={key}
+                                    >
+                                        <dt className="text-right text-sm font-semibold leading-6">
+                                            {key}:
+                                        </dt>
+                                        <dd className="mt-1 text-sm leading-6 sm:col-span-2 sm:mt-0">
+                                            {value}
+                                        </dd>
+                                    </div>
+                                ),
+                            )}
+
+                        <div className="px-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                            <dt className="text-right text-sm font-semibold leading-6">
+                                Provenance type:
+                            </dt>
+                            <dd className="mt-1 text-sm font-bold leading-6 sm:col-span-2 sm:mt-0">
+                                {provenanceType}
                             </dd>
                         </div>
                     </dl>

--- a/apps/clearance_ui/src/pages/packages/[purl]/license_conclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/license_conclusions.tsx
@@ -8,7 +8,15 @@ import ClearanceToolbar from "@/components/ClearanceToolbar";
 
 const PackageLicenseConclusions = () => {
     const router = useRouter();
-    const purl = router.query.purl as string;
+    const purl = router.query.purl;
+
+    if (!purl) {
+        return <div>Loading...</div>;
+    }
+    if (typeof purl !== "string") {
+        return <div>Invalid purl</div>;
+    }
+
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />

--- a/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
@@ -8,7 +8,15 @@ import ClearanceToolbar from "@/components/ClearanceToolbar";
 
 const PackagePathExclusions = () => {
     const router = useRouter();
-    const purl = router.query.purl as string;
+    const purl = router.query.purl;
+
+    if (!purl) {
+        return <div>Loading...</div>;
+    }
+    if (typeof purl !== "string") {
+        return <div>Invalid purl</div>;
+    }
+
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />


### PR DESCRIPTION
With this PR, details about an opened package is shown in the Package Info tab of the clearance toolbar.  With it, the dropdown (Accordion) component is also removed from the navigation bar, which now shows cleanly the clean PURL and an opened file (with path), when applicable.