### PR TITLE
Do 544 edit count endpoint for license conclusions

### DIFF
--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -2425,8 +2425,11 @@ export const findLicenseConclusions = async (
         | "createdAt"
         | "updatedAt",
     orderPropertyValue: "asc" | "desc" | undefined,
+    purl: string | undefined,
     contextPurl: string | undefined,
+    contextPurlStrict: boolean,
     username: string | undefined,
+    usernameStrict: boolean,
     detectedLicense: string | undefined,
     concludedLicense: string | undefined,
     comment: string | undefined,
@@ -2487,11 +2490,70 @@ export const findLicenseConclusions = async (
                 skip: skip,
                 take: take,
                 where: {
+                    OR: purl
+                        ? [
+                              /*
+                               * Find license conclusions made in the context of the specified package
+                               */
+                              {
+                                  file: {
+                                      filetrees: {
+                                          some: {
+                                              package: {
+                                                  purl: purl,
+                                              },
+                                          },
+                                      },
+                                  },
+                                  contextPurl: purl,
+                              },
+                              /*
+                               * Find license conclusions made in the context of a package different from
+                               * the specified one. Here the local value has to be false, as otherwise the
+                               * license conclusion shouldn't be applied in the files of the specified
+                               * package.
+                               */
+                              {
+                                  file: {
+                                      filetrees: {
+                                          some: {
+                                              package: {
+                                                  purl: purl,
+                                              },
+                                          },
+                                      },
+                                  },
+                                  contextPurl: {
+                                      not: purl,
+                                  },
+                                  local: false,
+                              },
+                          ]
+                        : undefined,
                     contextPurl: {
-                        contains: contextPurl,
+                        /*
+                         * If the purl is specified, and the local value is set to true,
+                         * the contextPurl cannot be used, as it has to be the same as the
+                         * purl. This is also mentioned in the API documentation.
+                         */
+                        equals:
+                            purl && local === true
+                                ? undefined
+                                : contextPurlStrict
+                                  ? contextPurl
+                                  : undefined,
+                        contains:
+                            purl && local === true
+                                ? undefined
+                                : !contextPurlStrict
+                                  ? contextPurl
+                                  : undefined,
                     },
                     user: {
-                        username: username,
+                        username: {
+                            equals: usernameStrict ? username : undefined,
+                            contains: !usernameStrict ? username : undefined,
+                        },
                     },
                     detectedLicenseExpressionSPDX: {
                         contains: detectedLicense,

--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -2416,7 +2416,7 @@ export const findLicenseConclusions = async (
     skip: number | undefined,
     take: number | undefined,
     orderProperty:
-        | "pkg"
+        | "contextPurl"
         | "username"
         | "detectedLicenseExpressionSPDX"
         | "concludedLicenseExpressionSPDX"
@@ -2425,7 +2425,7 @@ export const findLicenseConclusions = async (
         | "createdAt"
         | "updatedAt",
     orderPropertyValue: "asc" | "desc" | undefined,
-    purl: string | undefined,
+    contextPurl: string | undefined,
     username: string | undefined,
     detectedLicense: string | undefined,
     concludedLicense: string | undefined,
@@ -2488,7 +2488,7 @@ export const findLicenseConclusions = async (
                 take: take,
                 where: {
                     contextPurl: {
-                        contains: purl,
+                        contains: contextPurl,
                     },
                     user: {
                         username: username,
@@ -2527,19 +2527,15 @@ export const findLicenseConclusions = async (
                     },
                 },
                 orderBy:
-                    orderProperty === "pkg"
+                    orderProperty === "username"
                         ? {
-                              contextPurl: orderPropertyValue,
+                              user: {
+                                  username: orderPropertyValue,
+                              },
                           }
-                        : orderProperty === "username"
-                          ? {
-                                user: {
-                                    username: orderPropertyValue,
-                                },
-                            }
-                          : {
-                                [orderProperty]: orderPropertyValue,
-                            },
+                        : {
+                              [orderProperty]: orderPropertyValue,
+                          },
             });
             break;
         } catch (error) {
@@ -4075,7 +4071,7 @@ export const countBulkConclusions = async (
 };
 
 export const countLicenseConclusions = async (
-    purl: string | undefined,
+    contextPurl: string | undefined,
     username: string | undefined,
     detectedLicense: string | undefined,
     concludedLicense: string | undefined,
@@ -4105,7 +4101,7 @@ export const countLicenseConclusions = async (
             count = await prisma.licenseConclusion.count({
                 where: {
                     contextPurl: {
-                        contains: purl,
+                        contains: contextPurl,
                     },
                     user: {
                         username: username,

--- a/apps/api/src/routes/user_router.ts
+++ b/apps/api/src/routes/user_router.ts
@@ -242,7 +242,7 @@ userRouter.get(
     async (req, res) => {
         try {
             const fileSha256 = req.params.sha256;
-            const purl = req.params.purl.replace(/%2F/g, "/");
+            const purl = req.params.purl;
 
             let licenseConclusions =
                 await dbQueries.findLicenseConclusionsByFileSha256(fileSha256);

--- a/apps/api/src/routes/user_router.ts
+++ b/apps/api/src/routes/user_router.ts
@@ -119,7 +119,7 @@ userRouter.get("/license-conclusions", async (req, res) => {
                 !req.query.sortBy && !req.query.sortOrder
                     ? "desc"
                     : req.query.sortOrder,
-                req.query.purl,
+                req.query.contextPurl,
                 req.query.username,
                 req.query.detectedLicense,
                 req.query.concludedLicense,
@@ -192,7 +192,7 @@ userRouter.get("/license-conclusions", async (req, res) => {
 userRouter.get("/license-conclusions/count", async (req, res) => {
     try {
         const licenseConclusionsCount = await dbQueries.countLicenseConclusions(
-            req.query.purl,
+            req.query.contextPurl,
             req.query.username,
             req.query.detectedLicense,
             req.query.concludedLicense,

--- a/apps/clearance_ui/src/components/license_conclusion_table/DataTable.tsx
+++ b/apps/clearance_ui/src/components/license_conclusion_table/DataTable.tsx
@@ -58,7 +58,10 @@ export function DataTable<TData, TValue>({
     const [data, setData] = useState(initialData);
     const [editedRows, setEditedRows] = useState({});
 
-    const [purl, setPurl] = useQueryState("purl", parseAsString);
+    const [contextPurl, setContextPurl] = useQueryState(
+        "contextPurl",
+        parseAsString,
+    );
     // The setPageIndex cannot be recognized as a callable expression without the pageIndex, so it
     // is added here and an eslint-disable-next-line is added to ignore the unused variable
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -66,8 +69,11 @@ export function DataTable<TData, TValue>({
         "pageIndex",
         parseAsInteger.withDefault(1),
     );
-    const [inputValue, setInputValue] = useState<string>(purl || "");
-    const debounceSetPurl = useMemo(() => debounce(setPurl, 300), [setPurl]);
+    const [inputValue, setInputValue] = useState<string>(contextPurl || "");
+    const debounceSetPurl = useMemo(
+        () => debounce(setContextPurl, 300),
+        [setContextPurl],
+    );
 
     useEffect(() => {
         setData(initialData);

--- a/apps/clearance_ui/src/components/license_conclusion_table/LicenseConclusionList.tsx
+++ b/apps/clearance_ui/src/components/license_conclusion_table/LicenseConclusionList.tsx
@@ -28,12 +28,12 @@ const LicenseConclusionList = ({ user }: LicenseConclusionListProps) => {
         "pageIndex",
         parseAsInteger.withDefault(1),
     );
-    const [purl] = useQueryState("purl", parseAsString);
+    const [contextPurl] = useQueryState("contextPurl", parseAsString);
 
     const [sortBy, setSortBy] = useQueryState(
         "sortBy",
         parseAsStringEnum([
-            "pkg",
+            "contextPurl",
             "detectedLicenseExpressionSPDX",
             "concludedLicenseExpressionSPDX",
             "comment",
@@ -51,7 +51,7 @@ const LicenseConclusionList = ({ user }: LicenseConclusionListProps) => {
         {
             withCredentials: true,
             queries: {
-                purl: purl !== null ? purl : undefined,
+                contextPurl: contextPurl !== null ? contextPurl : undefined,
                 /*
                  * The initial idea of these queries was to fetch the license conclusions that are
                  * not part of a bulk conclusion (and their count) by setting the bulkConclusionId to
@@ -74,7 +74,7 @@ const LicenseConclusionList = ({ user }: LicenseConclusionListProps) => {
                 pageSize,
                 sortBy: sortBy !== null ? sortBy : undefined,
                 sortOrder: sortOrder !== null ? sortOrder : undefined,
-                purl: purl !== null ? purl : undefined,
+                contextPurl: contextPurl !== null ? contextPurl : undefined,
                 //bulkConclusionId: null,
                 hasBulkConclusionId: false,
             },

--- a/apps/clearance_ui/src/components/license_conclusion_table/columns.tsx
+++ b/apps/clearance_ui/src/components/license_conclusion_table/columns.tsx
@@ -38,7 +38,7 @@ export const columns = (
     sortOrder: string | null,
     setSortBy: <Shallow>(
         value:
-            | "pkg"
+            | "contextPurl"
             | "username"
             | "detectedLicenseExpressionSPDX"
             | "concludedLicenseExpressionSPDX"
@@ -47,7 +47,7 @@ export const columns = (
             | "updatedAt"
             | ((
                   old:
-                      | "pkg"
+                      | "contextPurl"
                       | "username"
                       | "detectedLicenseExpressionSPDX"
                       | "concludedLicenseExpressionSPDX"
@@ -56,7 +56,7 @@ export const columns = (
                       | "updatedAt"
                       | null,
               ) =>
-                  | "pkg"
+                  | "contextPurl"
                   | "username"
                   | "detectedLicenseExpressionSPDX"
                   | "concludedLicenseExpressionSPDX"
@@ -140,8 +140,8 @@ export const columns = (
                         variant="ghost"
                         className="px-0"
                         onClick={() => {
-                            if (sortBy !== "pkg") {
-                                setSortBy("pkg");
+                            if (sortBy !== "contextPurl") {
+                                setSortBy("contextPurl");
                                 setSortOrder("asc");
                                 setPageIndex(1);
                             } else {
@@ -164,9 +164,9 @@ export const columns = (
                         <Label className="cursor-pointer font-bold">
                             Package
                         </Label>
-                        {sortBy === "pkg" && sortOrder === "desc" ? (
+                        {sortBy === "contextPurl" && sortOrder === "desc" ? (
                             <ChevronDownIcon className="ml-2 h-4 w-4" />
-                        ) : sortBy === "pkg" && sortOrder === "asc" ? (
+                        ) : sortBy === "contextPurl" && sortOrder === "asc" ? (
                             <ChevronUpIcon className="ml-2 h-4 w-4" />
                         ) : (
                             <ChevronsUpDownIcon className="ml-2 h-4 w-4" />

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -4767,65 +4767,94 @@ declare const userAPI: [
                 schema: zod.ZodOptional<zod.ZodEnum<["asc", "desc"]>>;
             },
             {
+                name: "purl";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
                 name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
                 description: string;
             },
             {
+                name: "contextPurlStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
+            },
+            {
                 name: "username";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
+                name: "usernameStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "detectedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "concludedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "comment";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "local";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "bulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodNumber>;
+                description: string;
             },
             {
                 name: "hasBulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "createdAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "createdAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
         ];
         response: zod.ZodObject<
@@ -4892,6 +4921,22 @@ declare const userAPI: [
                                         >,
                                         "many"
                                     >;
+                                    inQueryPurl: zod.ZodArray<
+                                        zod.ZodObject<
+                                            {
+                                                path: zod.ZodString;
+                                            },
+                                            "strip",
+                                            zod.ZodTypeAny,
+                                            {
+                                                path: string;
+                                            },
+                                            {
+                                                path: string;
+                                            }
+                                        >,
+                                        "many"
+                                    >;
                                 },
                                 "strip",
                                 zod.ZodTypeAny,
@@ -4903,6 +4948,9 @@ declare const userAPI: [
                                         path: string;
                                         purl: string;
                                     }[];
+                                    inQueryPurl: {
+                                        path: string;
+                                    }[];
                                 },
                                 {
                                     inContextPurl: {
@@ -4911,6 +4959,9 @@ declare const userAPI: [
                                     additionalMatches: {
                                         path: string;
                                         purl: string;
+                                    }[];
+                                    inQueryPurl: {
+                                        path: string;
                                     }[];
                                 }
                             >;
@@ -4938,6 +4989,9 @@ declare const userAPI: [
                                     path: string;
                                     purl: string;
                                 }[];
+                                inQueryPurl: {
+                                    path: string;
+                                }[];
                             };
                         },
                         {
@@ -4960,6 +5014,9 @@ declare const userAPI: [
                                 additionalMatches: {
                                     path: string;
                                     purl: string;
+                                }[];
+                                inQueryPurl: {
+                                    path: string;
                                 }[];
                             };
                         }
@@ -4991,6 +5048,9 @@ declare const userAPI: [
                             path: string;
                             purl: string;
                         }[];
+                        inQueryPurl: {
+                            path: string;
+                        }[];
                     };
                 }[];
             },
@@ -5015,6 +5075,9 @@ declare const userAPI: [
                         additionalMatches: {
                             path: string;
                             purl: string;
+                        }[];
+                        inQueryPurl: {
+                            path: string;
                         }[];
                     };
                 }[];
@@ -11658,65 +11721,94 @@ declare const dosAPI: [
                 schema: zod.ZodOptional<zod.ZodEnum<["asc", "desc"]>>;
             },
             {
+                name: "purl";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
                 name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
                 description: string;
             },
             {
+                name: "contextPurlStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
+            },
+            {
                 name: "username";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
+                name: "usernameStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "detectedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "concludedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "comment";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "local";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "bulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodNumber>;
+                description: string;
             },
             {
                 name: "hasBulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "createdAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "createdAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
         ];
         response: zod.ZodObject<
@@ -11783,6 +11875,22 @@ declare const dosAPI: [
                                         >,
                                         "many"
                                     >;
+                                    inQueryPurl: zod.ZodArray<
+                                        zod.ZodObject<
+                                            {
+                                                path: zod.ZodString;
+                                            },
+                                            "strip",
+                                            zod.ZodTypeAny,
+                                            {
+                                                path: string;
+                                            },
+                                            {
+                                                path: string;
+                                            }
+                                        >,
+                                        "many"
+                                    >;
                                 },
                                 "strip",
                                 zod.ZodTypeAny,
@@ -11794,6 +11902,9 @@ declare const dosAPI: [
                                         path: string;
                                         purl: string;
                                     }[];
+                                    inQueryPurl: {
+                                        path: string;
+                                    }[];
                                 },
                                 {
                                     inContextPurl: {
@@ -11802,6 +11913,9 @@ declare const dosAPI: [
                                     additionalMatches: {
                                         path: string;
                                         purl: string;
+                                    }[];
+                                    inQueryPurl: {
+                                        path: string;
                                     }[];
                                 }
                             >;
@@ -11829,6 +11943,9 @@ declare const dosAPI: [
                                     path: string;
                                     purl: string;
                                 }[];
+                                inQueryPurl: {
+                                    path: string;
+                                }[];
                             };
                         },
                         {
@@ -11851,6 +11968,9 @@ declare const dosAPI: [
                                 additionalMatches: {
                                     path: string;
                                     purl: string;
+                                }[];
+                                inQueryPurl: {
+                                    path: string;
                                 }[];
                             };
                         }
@@ -11882,6 +12002,9 @@ declare const dosAPI: [
                             path: string;
                             purl: string;
                         }[];
+                        inQueryPurl: {
+                            path: string;
+                        }[];
                     };
                 }[];
             },
@@ -11906,6 +12029,9 @@ declare const dosAPI: [
                         additionalMatches: {
                             path: string;
                             purl: string;
+                        }[];
+                        inQueryPurl: {
+                            path: string;
                         }[];
                     };
                 }[];

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -4749,7 +4749,7 @@ declare const userAPI: [
                 schema: zod.ZodOptional<
                     zod.ZodEnum<
                         [
-                            "pkg",
+                            "contextPurl",
                             "username",
                             "detectedLicenseExpressionSPDX",
                             "concludedLicenseExpressionSPDX",
@@ -4767,9 +4767,10 @@ declare const userAPI: [
                 schema: zod.ZodOptional<zod.ZodEnum<["asc", "desc"]>>;
             },
             {
-                name: "purl";
+                name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "username";
@@ -4922,13 +4923,13 @@ declare const userAPI: [
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                             affectedPaths: {
                                 inContextPurl: {
                                     path: string;
@@ -4945,13 +4946,13 @@ declare const userAPI: [
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                             affectedPaths: {
                                 inContextPurl: {
                                     path: string;
@@ -4975,13 +4976,13 @@ declare const userAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                     affectedPaths: {
                         inContextPurl: {
                             path: string;
@@ -5000,13 +5001,13 @@ declare const userAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                     affectedPaths: {
                         inContextPurl: {
                             path: string;
@@ -5117,9 +5118,10 @@ declare const userAPI: [
         description: "Get count of license conclusions";
         parameters: [
             {
-                name: "purl";
+                name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "username";
@@ -5332,26 +5334,26 @@ declare const userAPI: [
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                         },
                         {
                             id: number;
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                         }
                     >,
                     "many"
@@ -5365,13 +5367,13 @@ declare const userAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                 }[];
             },
             {
@@ -5380,13 +5382,13 @@ declare const userAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                 }[];
             }
         >;
@@ -6609,12 +6611,12 @@ declare const userAPI: [
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
                             pattern: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
-                            contextPurl: string;
                         },
                         {
                             id: number;
@@ -6633,12 +6635,12 @@ declare const userAPI: [
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
                             pattern: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
-                            contextPurl: string;
                         }
                     >,
                     "many"
@@ -6664,12 +6666,12 @@ declare const userAPI: [
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
                     pattern: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
-                    contextPurl: string;
                 }[];
             },
             {
@@ -6690,12 +6692,12 @@ declare const userAPI: [
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
                     pattern: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
-                    contextPurl: string;
                 }[];
             }
         >;
@@ -11638,7 +11640,7 @@ declare const dosAPI: [
                 schema: zod.ZodOptional<
                     zod.ZodEnum<
                         [
-                            "pkg",
+                            "contextPurl",
                             "username",
                             "detectedLicenseExpressionSPDX",
                             "concludedLicenseExpressionSPDX",
@@ -11656,9 +11658,10 @@ declare const dosAPI: [
                 schema: zod.ZodOptional<zod.ZodEnum<["asc", "desc"]>>;
             },
             {
-                name: "purl";
+                name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "username";
@@ -11811,13 +11814,13 @@ declare const dosAPI: [
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                             affectedPaths: {
                                 inContextPurl: {
                                     path: string;
@@ -11834,13 +11837,13 @@ declare const dosAPI: [
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                             affectedPaths: {
                                 inContextPurl: {
                                     path: string;
@@ -11864,13 +11867,13 @@ declare const dosAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                     affectedPaths: {
                         inContextPurl: {
                             path: string;
@@ -11889,13 +11892,13 @@ declare const dosAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                     affectedPaths: {
                         inContextPurl: {
                             path: string;
@@ -12006,9 +12009,10 @@ declare const dosAPI: [
         description: "Get count of license conclusions";
         parameters: [
             {
-                name: "purl";
+                name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "username";
@@ -12221,26 +12225,26 @@ declare const dosAPI: [
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                         },
                         {
                             id: number;
                             detectedLicenseExpressionSPDX: string | null;
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
                             bulkConclusionId: number | null;
-                            contextPurl: string;
                         }
                     >,
                     "many"
@@ -12254,13 +12258,13 @@ declare const dosAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                 }[];
             },
             {
@@ -12269,13 +12273,13 @@ declare const dosAPI: [
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
                     bulkConclusionId: number | null;
-                    contextPurl: string;
                 }[];
             }
         >;
@@ -13498,12 +13502,12 @@ declare const dosAPI: [
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
                             pattern: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
-                            contextPurl: string;
                         },
                         {
                             id: number;
@@ -13522,12 +13526,12 @@ declare const dosAPI: [
                             concludedLicenseExpressionSPDX: string;
                             comment: string | null;
                             pattern: string | null;
+                            contextPurl: string;
                             local: boolean;
                             updatedAt: Date;
                             user: {
                                 username: string;
                             };
-                            contextPurl: string;
                         }
                     >,
                     "many"
@@ -13553,12 +13557,12 @@ declare const dosAPI: [
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
                     pattern: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
-                    contextPurl: string;
                 }[];
             },
             {
@@ -13579,12 +13583,12 @@ declare const dosAPI: [
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
                     pattern: string | null;
+                    contextPurl: string;
                     local: boolean;
                     updatedAt: Date;
                     user: {
                         username: string;
                     };
-                    contextPurl: string;
                 }[];
             }
         >;

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -5181,65 +5181,94 @@ declare const userAPI: [
         description: "Get count of license conclusions";
         parameters: [
             {
+                name: "purl";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
                 name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
                 description: string;
             },
             {
+                name: "contextPurlStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
+            },
+            {
                 name: "username";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
+                name: "usernameStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "detectedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "concludedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "comment";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "local";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "bulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodNumber>;
+                description: string;
             },
             {
                 name: "hasBulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "createdAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "createdAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
         ];
         response: zod.ZodObject<
@@ -12135,65 +12164,94 @@ declare const dosAPI: [
         description: "Get count of license conclusions";
         parameters: [
             {
+                name: "purl";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
                 name: "contextPurl";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
                 description: string;
             },
             {
+                name: "contextPurlStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
+            },
+            {
                 name: "username";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
+            },
+            {
+                name: "usernameStrict";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "detectedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "concludedLicense";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "comment";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodString>;
+                description: string;
             },
             {
                 name: "local";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "bulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodNumber>;
+                description: string;
             },
             {
                 name: "hasBulkConclusionId";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodBoolean>;
+                description: string;
             },
             {
                 name: "createdAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "createdAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtGte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
             {
                 name: "updatedAtLte";
                 type: "Query";
                 schema: zod.ZodOptional<zod.ZodDate>;
+                description: string;
             },
         ];
         response: zod.ZodObject<

--- a/packages/validation-helpers/src/api/apis/user.ts
+++ b/packages/validation-helpers/src/api/apis/user.ts
@@ -65,66 +65,103 @@ export const userAPI = makeApi([
                 schema: commonSchemas.QueryParamSortOrder,
             },
             {
+                name: "purl",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterValue,
+                description:
+                    "Filter by purl (exact match). Use this to get the license conclusions affecting the files in the specified purl, regardless of whether the conclusions were made in the context of the purl or not.",
+            },
+            {
                 name: "contextPurl",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
                 description:
-                    "Filter by context purl (use this to get only the license conclusions made in the context of the specified purl)",
+                    "Filter by context purl. Use this to get only the license conclusions made in the context of the specified purl. Please note that if a purl is specified, and the local value is set to true, the context purl will be ignored, as it has to be the same as the purl.",
+            },
+            {
+                name: "contextPurlStrict",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterBoolean,
+                description:
+                    "Choose whether to filter by context purl strictly (exact match) or not (substring match). Defaults to false.",
             },
             {
                 name: "username",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by username",
+            },
+            {
+                name: "usernameStrict",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterBoolean,
+                description:
+                    "Choose whether to filter by username strictly (exact match) or not (substring match). Defaults to false.",
             },
             {
                 name: "detectedLicense",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by detected license (substring match)",
             },
             {
                 name: "concludedLicense",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by concluded license (substring match)",
             },
             {
                 name: "comment",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by comment (substring match)",
             },
             {
                 name: "local",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterBoolean,
+                description: "Filter by local value",
             },
             {
                 name: "bulkConclusionId",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterInt,
+                description: "Filter by bulk conclusion id",
             },
             {
                 name: "hasBulkConclusionId",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterBoolean,
+                description:
+                    "Refine results to include only entries with or without a bulk conclusion id.",
             },
             {
                 name: "createdAtGte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine results to include only entries created on or after the specified date.",
             },
             {
                 name: "createdAtLte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine results to include only entries created on or before the specified date.",
             },
             {
                 name: "updatedAtGte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine results to include only entries updated on or after the specified date.",
             },
             {
                 name: "updatedAtLte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine results to include only entries updated on or before the specified date.",
             },
         ],
         response: schemas.GetLicenseConclusionsRes,

--- a/packages/validation-helpers/src/api/apis/user.ts
+++ b/packages/validation-helpers/src/api/apis/user.ts
@@ -174,66 +174,103 @@ export const userAPI = makeApi([
         description: "Get count of license conclusions",
         parameters: [
             {
+                name: "purl",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterValue,
+                description:
+                    "Filter by purl (exact match). Use this to get the count of all license conclusions affecting the files in the specified purl, regardless of whether the conclusions were made in the context of the purl or not.",
+            },
+            {
                 name: "contextPurl",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
                 description:
-                    "Filter by context purl (use this to get the count of license conclusions made in the context of the specified purl)",
+                    "Filter by context purl. Use this to get the count of only the license conclusions made in the context of the specified purl. Please note that if a purl is specified, and the local value is set to true, the context purl will be ignored, as it has to be the same as the purl.",
+            },
+            {
+                name: "contextPurlStrict",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterBoolean,
+                description:
+                    "Choose whether to filter by context purl strictly (exact match) or not (substring match). Defaults to false.",
             },
             {
                 name: "username",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by username",
+            },
+            {
+                name: "usernameStrict",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterBoolean,
+                description:
+                    "Choose whether to filter by username strictly (exact match) or not (substring match). Defaults to false.",
             },
             {
                 name: "detectedLicense",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by detected license (substring match)",
             },
             {
                 name: "concludedLicense",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by concluded license (substring match)",
             },
             {
                 name: "comment",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description: "Filter by comment (substring match)",
             },
             {
                 name: "local",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterBoolean,
+                description: "Filter by local value",
             },
             {
                 name: "bulkConclusionId",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterInt,
+                description: "Filter by bulk conclusion id",
             },
             {
                 name: "hasBulkConclusionId",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterBoolean,
+                description:
+                    "Refine count to include only entries with or without a bulk conclusion id.",
             },
             {
                 name: "createdAtGte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine count to include only entries created on or after the specified date.",
             },
             {
                 name: "createdAtLte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine count to include only entries created on or before the specified date.",
             },
             {
                 name: "updatedAtGte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine count to include only entries updated on or after the specified date.",
             },
             {
                 name: "updatedAtLte",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterDate,
+                description:
+                    "Refine count to include only entries updated on or before the specified date.",
             },
         ],
         response: commonSchemas.GetCountRes,

--- a/packages/validation-helpers/src/api/apis/user.ts
+++ b/packages/validation-helpers/src/api/apis/user.ts
@@ -65,9 +65,11 @@ export const userAPI = makeApi([
                 schema: commonSchemas.QueryParamSortOrder,
             },
             {
-                name: "purl",
+                name: "contextPurl",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description:
+                    "Filter by context purl (use this to get only the license conclusions made in the context of the specified purl)",
             },
             {
                 name: "username",
@@ -135,9 +137,11 @@ export const userAPI = makeApi([
         description: "Get count of license conclusions",
         parameters: [
             {
-                name: "purl",
+                name: "contextPurl",
                 type: "Query",
                 schema: commonSchemas.QueryParamFilterValue,
+                description:
+                    "Filter by context purl (use this to get the count of license conclusions made in the context of the specified purl)",
             },
             {
                 name: "username",

--- a/packages/validation-helpers/src/api/schemas/user_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/user_schemas.ts
@@ -86,6 +86,11 @@ export const GetLicenseConclusionsRes = z.object({
                         purl: z.string(),
                     }),
                 ),
+                inQueryPurl: z.array(
+                    z.object({
+                        path: z.string(),
+                    }),
+                ),
             }),
         }),
     ),

--- a/packages/validation-helpers/src/api/schemas/user_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/user_schemas.ts
@@ -50,7 +50,7 @@ export const PutUserRes = z.object({
 //------------------ GET license conclusion -------------------
 export const QueryParamSortLCBy = z
     .enum([
-        "pkg",
+        "contextPurl",
         "username",
         "detectedLicenseExpressionSPDX",
         "concludedLicenseExpressionSPDX",


### PR DESCRIPTION
This PR edits the GET license-conclusions and GET license-conclusions/count endpoints so that they can be used to fetch the license conclusions affecting files in a specific package, regardless of whether the license conclusion was made in the context of that package or not.