### PR TITLE
Do 536 show path exclusions of a package

### DIFF
--- a/apps/clearance_ui/src/components/ClearanceToolbar.tsx
+++ b/apps/clearance_ui/src/components/ClearanceToolbar.tsx
@@ -48,7 +48,7 @@ const ClearanceToolbar = () => {
                         router.pathname.includes("/tree/")
                         ? "border-b-4 border-[#ff3366] font-semibold"
                         : "",
-                    "inline-block rounded-sm px-2 py-1 text-xs hover:bg-gray-100 hover:text-gray-900",
+                    "hover:bg-muted inline-block rounded-sm px-2 py-1 text-xs",
                 )}
             >
                 <div className="flex items-center">

--- a/apps/clearance_ui/src/components/ClearanceToolbar.tsx
+++ b/apps/clearance_ui/src/components/ClearanceToolbar.tsx
@@ -10,13 +10,30 @@ import { LuFileStack, LuFolderTree } from "react-icons/lu";
 import { TbFoldersOff } from "react-icons/tb";
 import { TfiPencil } from "react-icons/tfi";
 import { useShallow } from "zustand/react/shallow";
+import { userHooks } from "@/hooks/zodiosHooks";
 import useMainUiStore from "@/store/mainui.store";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 const ClearanceToolbar = () => {
     const router = useRouter();
     const [purl, path] = useMainUiStore(
         useShallow((state) => [state.purl, state.path]),
+    );
+
+    // Get the counts of different clearance items for this package, to show in the toolbar
+    const { data: licenseConclusionCount } =
+        userHooks.useGetLicenseConclusionsCount(
+            { withCredentials: true, queries: { purl: purl } },
+            { enabled: !!purl },
+        );
+    const { data: bulkConclusionCount } = userHooks.useGetBulkConclusionsCount(
+        { withCredentials: true, queries: { purl: purl, purlStrict: true } },
+        { enabled: !!purl },
+    );
+    const { data: pathExclusionCount } = userHooks.useGetPathExclusionsCount(
+        { withCredentials: true, queries: { purl: purl, purlStrict: true } },
+        { enabled: !!purl },
     );
 
     return (
@@ -47,7 +64,7 @@ const ClearanceToolbar = () => {
                     router.pathname === "/packages/[purl]/details"
                         ? "border-b-4 border-[#ff3366] font-semibold"
                         : "",
-                    "inline-block rounded-sm px-2 py-1 text-xs hover:bg-gray-100 hover:text-gray-900",
+                    "hover:bg-muted inline-block rounded-sm px-2 py-1 text-xs",
                 )}
             >
                 <div className="flex items-center">
@@ -65,12 +82,21 @@ const ClearanceToolbar = () => {
                     router.pathname === "/packages/[purl]/license_conclusions"
                         ? "border-b-4 border-[#ff3366] font-semibold"
                         : "",
-                    "inline-block rounded-sm px-2 py-1 text-xs hover:bg-gray-100 hover:text-gray-900",
+                    "hover:bg-muted inline-block rounded-sm px-2 py-1 text-xs",
                 )}
             >
                 <div className="flex items-center">
                     <TfiPencil className="mr-1" />
-                    License Conclusions
+                    <span>License Conclusions</span>
+                    {licenseConclusionCount &&
+                        licenseConclusionCount.count > 0 && (
+                            <Badge
+                                variant="secondary"
+                                className="ml-1 text-xs font-semibold"
+                            >
+                                {licenseConclusionCount.count}
+                            </Badge>
+                        )}
                 </div>
             </Link>
 
@@ -81,12 +107,20 @@ const ClearanceToolbar = () => {
                     router.pathname === "/packages/[purl]/bulk_conclusions"
                         ? "border-b-4 border-[#ff3366] font-semibold"
                         : "",
-                    "inline-block rounded-sm px-2 py-1 text-xs hover:bg-gray-100 hover:text-gray-900",
+                    "hover:bg-muted inline-block rounded-sm px-2 py-1 text-xs",
                 )}
             >
                 <div className="flex items-center">
                     <LuFileStack className="mr-1" />
-                    Bulk Conclusions
+                    <span>Bulk Conclusions</span>
+                    {bulkConclusionCount && bulkConclusionCount.count > 0 && (
+                        <Badge
+                            variant="secondary"
+                            className="ml-1 text-xs font-semibold"
+                        >
+                            {bulkConclusionCount.count}
+                        </Badge>
+                    )}
                 </div>
             </Link>
 
@@ -97,12 +131,20 @@ const ClearanceToolbar = () => {
                     router.pathname === "/packages/[purl]/path_exclusions"
                         ? "border-b-4 border-[#ff3366] font-semibold"
                         : "",
-                    "inline-block rounded-sm px-2 py-1 text-xs hover:bg-gray-100 hover:text-gray-900",
+                    "hover:bg-muted inline-block rounded-sm px-2 py-1 text-xs",
                 )}
             >
                 <div className="flex items-center">
                     <TbFoldersOff className="mr-1" />
-                    Path Exclusions
+                    <span>Path Exclusions</span>
+                    {pathExclusionCount && pathExclusionCount.count > 0 && (
+                        <Badge
+                            variant="secondary"
+                            className="ml-1 text-xs font-semibold"
+                        >
+                            {pathExclusionCount.count}
+                        </Badge>
+                    )}
                 </div>
             </Link>
         </div>

--- a/apps/clearance_ui/src/components/delete_item/DeleteBulkConclusion.tsx
+++ b/apps/clearance_ui/src/components/delete_item/DeleteBulkConclusion.tsx
@@ -16,39 +16,38 @@ type Props = {
 
 const DeleteBulkConclusion = ({ id }: Props) => {
     const { toast } = useToast();
-    const keyFiletree = userHooks.getKeyByPath(
-        "get",
-        "/packages/:purl/filetrees",
+    const keyLCs = userHooks.getKeyByAlias(
+        "GetLicenseConclusionsForFileInPackage",
     );
-    const keyLicenseConclusion = userHooks.getKeyByPath(
-        "get",
-        "/license-conclusions",
+    const keyFiletree = userHooks.getKeyByAlias("GetFileTree");
+    const keyLicenseConclusion = userHooks.getKeyByAlias(
+        "GetLicenseConclusions",
     );
-    const keyLCs = userHooks.getKeyByPath(
-        "get",
-        "/packages/:purl/files/:sha256/license-conclusions/",
+
+    const keyBulkConclusion = userHooks.getKeyByAlias("GetBulkConclusions");
+    const keyBulkConclusionCountByPurl = userHooks.getKeyByAlias(
+        "GetBulkConclusionsCount",
     );
-    const keyBulkCuration = userHooks.getKeyByAlias("GetBulkConclusions");
     const queryClient = useQueryClient();
     const deleteActions: DeleteAction[] = [];
 
-    const { data: bulkCuration } = userHooks.useGetBulkConclusionById({
+    const { data: bulkConclusion } = userHooks.useGetBulkConclusionById({
         withCredentials: true,
         params: {
             id: id,
         },
     });
 
-    if (bulkCuration) {
+    if (bulkConclusion) {
         deleteActions.push({
             dialogMessage: (
                 <>
                     This is a bulk license conclusion, concluding{" "}
-                    <strong>{bulkCuration.filePaths.length}</strong> files as{" "}
+                    <strong>{bulkConclusion.filePaths.length}</strong> files as{" "}
                     <strong>
-                        {bulkCuration.concludedLicenseExpressionSPDX}
+                        {bulkConclusion.concludedLicenseExpressionSPDX}
                     </strong>{" "}
-                    with the pattern <strong>{bulkCuration.pattern}</strong>.
+                    with the pattern <strong>{bulkConclusion.pattern}</strong>.
                     <br />
                     <br />
                     Do you want to delete this bulk conclusion?
@@ -60,11 +59,11 @@ const DeleteBulkConclusion = ({ id }: Props) => {
     }
 
     function deleteManyItems() {
-        deleteBulkCuration(undefined);
+        deleteBulkConclusion(undefined);
     }
 
     // Delete a bulk curation
-    const { mutate: deleteBulkCuration, isLoading: isBulkLoading } =
+    const { mutate: deleteBulkConclusion, isLoading: isBulkLoading } =
         userHooks.useDeleteBulkConclusion(
             {
                 withCredentials: true,
@@ -76,13 +75,14 @@ const DeleteBulkConclusion = ({ id }: Props) => {
                 onSuccess: () => {
                     toast({
                         title: "Delete successful",
-                        description: `Bulk license conclusion deleted successfully, ${bulkCuration?.filePaths.length} files affected.`,
+                        description: `Bulk license conclusion deleted successfully, ${bulkConclusion?.filePaths.length} files affected.`,
                     });
-                    // When a bulk curation is deleted, invalidate queries to refetch the data
+                    // When a bulk conclusion is deleted, invalidate the corresponding queries to refetch the data
                     queryClient.invalidateQueries(keyFiletree);
                     queryClient.invalidateQueries(keyLicenseConclusion);
-                    queryClient.invalidateQueries(keyBulkCuration);
+                    queryClient.invalidateQueries(keyBulkConclusion);
                     queryClient.invalidateQueries(keyLCs);
+                    queryClient.invalidateQueries(keyBulkConclusionCountByPurl);
                 },
                 onError: () => {
                     toast({

--- a/apps/clearance_ui/src/components/delete_item/DeletePathExclusion.tsx
+++ b/apps/clearance_ui/src/components/delete_item/DeletePathExclusion.tsx
@@ -26,6 +26,9 @@ const DeletePathExclusion = ({ data }: Props) => {
     const keyPathExclusionsByPurl = userHooks.getKeyByAlias(
         "GetPathExclusionsByPurl",
     );
+    const keyPathExclusionCountByPurl = userHooks.getKeyByAlias(
+        "GetPathExclusionsCount",
+    );
     const keyPathExclusions = userHooks.getKeyByAlias("GetPathExclusions");
     const queryClient = useQueryClient();
     const deleteActions: DeleteAction[] = [];
@@ -69,9 +72,10 @@ const DeletePathExclusion = ({ data }: Props) => {
                         description: "Path exclusion deleted successfully.",
                     });
 
-                    // When a path exclusion deleted, invalidate the query to refetch the data
+                    // When a path exclusion is deleted, invalidate the corresponding queries to refetch the data
                     queryClient.invalidateQueries(keyPathExclusions);
                     queryClient.invalidateQueries(keyPathExclusionsByPurl);
+                    queryClient.invalidateQueries(keyPathExclusionCountByPurl);
                 },
                 onError: () => {
                     toast({

--- a/apps/clearance_ui/src/components/license_conclusions/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/BulkConclusionForm.tsx
@@ -102,6 +102,9 @@ const BulkConclusionForm = ({ purl, className, setOpen }: Props) => {
     const keyLicenseConclusions = userHooks.getKeyByAlias(
         "GetLicenseConclusions",
     );
+    const keyBulkConclusionCountByPurl = userHooks.getKeyByAlias(
+        "GetBulkConclusionsCount",
+    );
 
     const queryClient = useQueryClient();
     const { mutate: addBulkConclusion, isLoading } =
@@ -127,10 +130,11 @@ const BulkConclusionForm = ({ purl, className, setOpen }: Props) => {
                         ${res.filesPackage} identical (SHA256) files affected in this package, 
                         ${res.filesAll} identical (SHA256) files affected in the database.`,
                     });
-                    // When a bulk curation is added, invalidate the queries to refetch the data
+                    // When a bulk conclusion is added, invalidate the corresponding queries to refetch the data
                     queryClient.invalidateQueries(keyLCs);
                     queryClient.invalidateQueries(keyFiletree);
                     queryClient.invalidateQueries(keyLicenseConclusions);
+                    queryClient.invalidateQueries(keyBulkConclusionCountByPurl);
                 },
                 onError: (error) => {
                     if (axios.isAxiosError(error)) {

--- a/apps/clearance_ui/src/components/license_conclusions/ConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/license_conclusions/ConclusionForm.tsx
@@ -95,14 +95,12 @@ const ConclusionForm = ({
         defaultValues,
     });
     const { errors } = useFormState({ control: form.control });
-
-    const keyLCs = userHooks.getKeyByPath(
-        "get",
-        "/packages/:purl/files/:sha256/license-conclusions/",
+    const keyLCs = userHooks.getKeyByAlias(
+        "GetLicenseConclusionsForFileInPackage",
     );
-    const keyFiletree = userHooks.getKeyByPath(
-        "get",
-        "/packages/:purl/filetrees",
+    const keyFiletree = userHooks.getKeyByAlias("GetFileTree");
+    const keyLicenseConclusionCountByPurl = userHooks.getKeyByAlias(
+        "GetLicenseConclusionsCount",
     );
     const queryClient = useQueryClient();
 
@@ -118,9 +116,10 @@ const ConclusionForm = ({
         },
         {
             onSuccess: () => {
-                // When a license conclusion is added, invalidate the file and filetree queries to refetch the data
+                // When a license conclusion is added, invalidate the corresponding queries to refetch the data
                 queryClient.invalidateQueries(keyLCs);
                 queryClient.invalidateQueries(keyFiletree);
+                queryClient.invalidateQueries(keyLicenseConclusionCountByPurl);
                 toast({
                     title: "License conclusion",
                     description: "License conclusion added successfully.",

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PackagePathExclusions.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PackagePathExclusions.tsx
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import React from "react";
+import { Loader2 } from "lucide-react";
+import { useUser } from "@/hooks/useUser";
+import { userHooks } from "@/hooks/zodiosHooks";
+import { toPathPurl } from "@/helpers/pathParamHelpers";
+
+type Props = {
+    purl: string;
+};
+
+const PackagePathExclusions = ({ purl }: Props) => {
+    const pathPurl = toPathPurl(purl);
+    const { data, isLoading, error } = userHooks.useGetPathExclusionsByPurl(
+        { withCredentials: true, params: { purl: pathPurl } },
+        { enabled: !!pathPurl },
+    );
+
+    // Get user from useUser hook, to decide what DB rights the user has for curations
+    let user = undefined;
+    user = useUser();
+    const userName = user ? user.username : "Guest";
+    const userRole = user ? user.role : "";
+
+    return (
+        <>
+            {isLoading && (
+                <div className="flex h-full items-center justify-center">
+                    <Loader2 className="mr-2 h-16 w-16 animate-spin" />
+                </div>
+            )}
+            {error && (
+                <div className="flex h-full items-center justify-center">
+                    <div>Error: {error.message}</div>
+                </div>
+            )}
+            {data && (
+                <div className="flex-1 border p-2">
+                    {data.pathExclusions.map((pe) => (
+                        <div key={pe.id}>
+                            <div>
+                                {
+                                    new Date(pe.updatedAt)
+                                        .toISOString()
+                                        .split("T")[0]
+                                }
+                            </div>
+                            <div>{pe.pattern}</div>
+                            <div>{pe.reason}</div>
+                            <div>{pe.comment}</div>
+                        </div>
+                    ))}
+                    ;
+                </div>
+            )}
+        </>
+    );
+};
+
+export default PackagePathExclusions;

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import { ZodiosResponseByAlias } from "@zodios/core";
 import { userAPI } from "validation-helpers";
+import { Separator } from "@/components/ui/separator";
 import DeletePathExclusion from "@/components/delete_item/DeletePathExclusion";
 import EditButton from "@/components/edit_item/EditButton";
 
@@ -27,10 +28,10 @@ const PathExclusion = ({
     editHandler,
 }: Props) => {
     return (
-        <div className="bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
-            <div className="flex-1 items-start text-left">
-                <div className="flex w-full flex-col gap-1 pr-2 text-sm">
-                    <div className="flex items-center justify-between">
+        <div className="hover:bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
+            <div className="mr-1 flex-1 items-start text-left">
+                <div className="flex w-full flex-col gap-1">
+                    <div className="flex items-center justify-between text-sm">
                         <span className="font-semibold">
                             {
                                 new Date(pathExclusion.updatedAt)
@@ -38,29 +39,36 @@ const PathExclusion = ({
                                     .split("T")[0]
                             }
                         </span>
-                        <span className="rounded-sm bg-orange-400 p-1 font-semibold">
+                        <span className="rounded-sm bg-orange-400 p-1 text-xs font-semibold">
                             {pathExclusion.user.username}
                         </span>
                     </div>
-                    <div className="rounded-sm p-1 font-semibold">
-                        {pathExclusion.pattern}
+                    <div className="text-xs">
+                        <span className="mr-1 font-semibold">
+                            Glob pattern:
+                        </span>
+                        <span className="rounded-sm bg-slate-200 dark:bg-slate-600">
+                            {pathExclusion.pattern}
+                        </span>
                     </div>
-                    <span className="text-smaller p-1">
-                        <span className="mr-1">Reason:</span>
+                    <div className="text-xs">
+                        <span className="mr-1 font-semibold">Reason:</span>
                         <span>{pathExclusion.reason}</span>
-                    </span>
-                    <span className="text-smaller italic">
-                        {pathExclusion.comment}
-                    </span>
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                        <span className="mr-1 font-semibold">Comment:</span>
+                        <span className="italic">{pathExclusion.comment}</span>
+                    </div>
                 </div>
             </div>
-            <div className="flex border">
+            <div className="flex pl-1">
                 {(userName === pathExclusion.user.username ||
                     userRole === "ADMIN") && (
-                    <div className="flex flex-row align-middle">
+                    <div className="flex items-center">
+                        <Separator orientation="vertical" className="w-[2px]" />
                         <EditButton
                             name="edit"
-                            className="mr-1 px-2"
+                            className="ml-2 mr-1 px-2"
                             onClick={() => editHandler(pathExclusion.id)}
                         />
                         <DeletePathExclusion data={pathExclusion} />

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import React from "react";
+import { ZodiosResponseByAlias } from "@zodios/core";
+import { userAPI } from "validation-helpers";
+import DeletePathExclusion from "@/components/delete_item/DeletePathExclusion";
+import EditButton from "@/components/edit_item/EditButton";
+
+type PathExclusion = ZodiosResponseByAlias<
+    typeof userAPI,
+    "GetPathExclusionsByPurl"
+>["pathExclusions"][0];
+
+type Props = {
+    pathExclusion: PathExclusion;
+    userName: string;
+    userRole: string;
+};
+
+const PathExclusion = ({ pathExclusion, userName, userRole }: Props) => {
+    return (
+        <div className="bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
+            <div
+                key={pathExclusion.id}
+                className="flex-1 items-start text-left"
+            >
+                <div className="flex w-full flex-col gap-1 pr-2 text-sm">
+                    <div className="mb-1 flex items-center justify-between">
+                        <span className="font-semibold">
+                            {
+                                new Date(pathExclusion.updatedAt)
+                                    .toISOString()
+                                    .split("T")[0]
+                            }
+                        </span>
+                        <span className="rounded-sm bg-orange-400 p-1 font-semibold">
+                            {pathExclusion.user.username}
+                        </span>
+                    </div>
+                    <div className="mb-1 rounded-sm p-1 font-semibold">
+                        {pathExclusion.pattern}
+                    </div>
+                    <span className="text-smaller">
+                        <span className="mr-1">Reason:</span>
+                        <span>{pathExclusion.reason}</span>
+                    </span>
+                    <span className="text-smaller italic">
+                        {pathExclusion.comment}
+                    </span>
+                </div>
+            </div>
+            <div key={`edit-${pathExclusion.id}`} className="flex border">
+                {(userName === pathExclusion.user.username ||
+                    userRole === "ADMIN") && (
+                    <div className="flex flex-row align-middle">
+                        <EditButton
+                            name="edit"
+                            className="mr-1 px-2"
+                            onClick={() => {}}
+                        />
+                        <DeletePathExclusion data={pathExclusion} />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default PathExclusion;

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
@@ -28,7 +28,10 @@ const PathExclusion = ({
     editHandler,
 }: Props) => {
     return (
-        <div className="hover:bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
+        <div
+            className="hover:bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2"
+            data-testid="path-exclusion"
+        >
             <div className="mr-1 flex-1 items-start text-left">
                 <div className="flex w-full flex-col gap-1">
                     <div className="flex items-center justify-between text-sm">

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
@@ -4,9 +4,10 @@
 
 import React from "react";
 import { ZodiosResponseByAlias } from "@zodios/core";
+import { Check, X } from "lucide-react";
 import { userAPI } from "validation-helpers";
-import DeletePathExclusion from "@/components/delete_item/DeletePathExclusion";
-import EditButton from "@/components/edit_item/EditButton";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 
 type PathExclusion = ZodiosResponseByAlias<
     typeof userAPI,
@@ -15,22 +16,15 @@ type PathExclusion = ZodiosResponseByAlias<
 
 type Props = {
     pathExclusion: PathExclusion;
-    userName: string;
-    userRole: string;
     editHandler: (id: number) => void;
 };
 
-const PathExclusion = ({
-    pathExclusion,
-    userName,
-    userRole,
-    editHandler,
-}: Props) => {
+const PathExclusion = ({ pathExclusion, editHandler }: Props) => {
     return (
         <div className="bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
-            <div className="flex-1 items-start text-left">
-                <div className="flex w-full flex-col gap-1 pr-2 text-sm">
-                    <div className="flex items-center justify-between">
+            <div className="mr-1 flex-1 items-start text-left">
+                <div className="flex w-full flex-col gap-1">
+                    <div className="flex items-center justify-between text-sm">
                         <span className="font-semibold">
                             {
                                 new Date(pathExclusion.updatedAt)
@@ -38,35 +32,42 @@ const PathExclusion = ({
                                     .split("T")[0]
                             }
                         </span>
-                        <span className="rounded-sm bg-orange-400 p-1 font-semibold">
+                        <span className="rounded-sm bg-orange-400 p-1 text-xs font-semibold">
                             {pathExclusion.user.username}
                         </span>
                     </div>
-                    <div className="rounded-sm p-1 font-semibold">
-                        {pathExclusion.pattern}
+                    <div className="text-xs">
+                        <span className="mr-1 font-semibold">
+                            Glob pattern:
+                        </span>
+                        <span className="rounded-sm bg-slate-200 dark:bg-slate-600">
+                            {pathExclusion.pattern}
+                        </span>
                     </div>
-                    <span className="text-smaller p-1">
-                        <span className="mr-1">Reason:</span>
+                    <div className="text-xs">
+                        <span className="mr-1 font-semibold">Reason:</span>
                         <span>{pathExclusion.reason}</span>
-                    </span>
-                    <span className="text-smaller p-1 italic">
-                        {pathExclusion.comment}
-                    </span>
-                    <span className="text-smaller p-1">EDIT MODE</span>
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                        <span className="mr-1 font-semibold">Comment:</span>
+                        <span className="italic">{pathExclusion.comment}</span>
+                    </div>
                 </div>
             </div>
-            <div className="flex border">
-                {(userName === pathExclusion.user.username ||
-                    userRole === "ADMIN") && (
-                    <div className="flex flex-row align-middle">
-                        <EditButton
-                            name="edit"
-                            className="mr-1 px-2"
-                            onClick={() => editHandler(pathExclusion.id)}
-                        />
-                        <DeletePathExclusion data={pathExclusion} />
-                    </div>
-                )}
+            <div className="flex pl-1">
+                <div className="flex items-center">
+                    <Separator orientation="vertical" className="w-[2px]" />
+                    <Button variant="outline" className="ml-2 mr-1 px-2">
+                        <Check size={16} className="text-green-400" />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        className="px-2"
+                        onClick={() => editHandler(-1)}
+                    >
+                        <X size={16} className="text-[#ff3366]" />
+                    </Button>
+                </div>
             </div>
         </div>
     );

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
@@ -234,6 +234,7 @@ const PathExclusionEditForm = ({ pathExclusion, editHandler }: Props) => {
                                 <Loader2 className="ml-2 mr-1 h-10 w-10 animate-spin" />
                             ) : (
                                 <Button
+                                    data-testid="path-exclusion-edit"
                                     variant="outline"
                                     type="submit"
                                     className="ml-2 mr-1 px-2"

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
@@ -49,9 +49,10 @@ const PathExclusion = ({
                         <span className="mr-1">Reason:</span>
                         <span>{pathExclusion.reason}</span>
                     </span>
-                    <span className="text-smaller italic">
+                    <span className="text-smaller p-1 italic">
                         {pathExclusion.comment}
                     </span>
+                    <span className="text-smaller p-1">EDIT MODE</span>
                 </div>
             </div>
             <div className="flex border">

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
@@ -3,11 +3,43 @@
 // SPDX-License-Identifier: MIT
 
 import React from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ZodiosResponseByAlias } from "@zodios/core";
-import { Check, X } from "lucide-react";
-import { userAPI } from "validation-helpers";
+import axios from "axios";
+import { Check, Loader2, X } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { userAPI, validReasons } from "validation-helpers";
+import { z } from "zod";
+import { userHooks } from "@/hooks/zodiosHooks";
 import { Button } from "@/components/ui/button";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+const exclusionFormSchema = z.object({
+    pattern: z.string().min(1, "Pattern cannot be empty"),
+    reason: z.string().min(1, "Please select a valid reason from this list"),
+    comment: z.string().optional(),
+});
+
+type ExclusionFormType = z.infer<typeof exclusionFormSchema>;
 
 type PathExclusion = ZodiosResponseByAlias<
     typeof userAPI,
@@ -19,58 +51,212 @@ type Props = {
     editHandler: (id: number) => void;
 };
 
-const PathExclusion = ({ pathExclusion, editHandler }: Props) => {
+const PathExclusionEditForm = ({ pathExclusion, editHandler }: Props) => {
+    const defaultValues: ExclusionFormType = {
+        pattern: pathExclusion.pattern || "",
+        reason: pathExclusion.reason || "",
+        comment: pathExclusion.comment || "",
+    };
+    const form = useForm<ExclusionFormType>({
+        resolver: zodResolver(exclusionFormSchema),
+        defaultValues,
+    });
+    const keyPathExclusionsByPurl = userHooks.getKeyByAlias(
+        "GetPathExclusionsByPurl",
+    );
+    const queryClient = useQueryClient();
+    const { toast } = useToast();
+
+    const { mutate: editPathExclusion, isLoading } =
+        userHooks.usePutPathExclusion(
+            {
+                withCredentials: true,
+                params: {
+                    id: pathExclusion.id || -1,
+                },
+            },
+            {
+                onSuccess: () => {
+                    toast({
+                        title: "Path exclusion",
+                        description:
+                            "Path exclusion edited and saved successfully.",
+                    });
+                    // When a path exclusions is edited, invalidate the query to refetch the data
+                    queryClient.invalidateQueries(keyPathExclusionsByPurl);
+                    // Close the edit form component and switch to the ordinary component view
+                    editHandler(-1);
+                },
+                onError: (error) => {
+                    if (axios.isAxiosError(error)) {
+                        if (error.response?.data?.path === "pattern") {
+                            form.setError("pattern", {
+                                type: "manual",
+                                message: error.response?.data?.message,
+                            });
+                        } else if (error.response?.data?.message) {
+                            form.setError("root", {
+                                type: "manual",
+                                message: error.response?.data?.message,
+                            });
+                        }
+                    } else {
+                        form.setError("root", {
+                            type: "manual",
+                            message: error.message,
+                        });
+                    }
+                },
+            },
+        );
+
+    const onSubmit = (data: ExclusionFormType) => {
+        editPathExclusion({
+            pattern: data.pattern,
+            reason: data.reason,
+            comment: data.comment,
+        });
+    };
+
     return (
-        <div className="bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
-            <div className="mr-1 flex-1 items-start text-left">
-                <div className="flex w-full flex-col gap-1">
-                    <div className="flex items-center justify-between text-sm">
-                        <span className="font-semibold">
-                            {
-                                new Date(pathExclusion.updatedAt)
-                                    .toISOString()
-                                    .split("T")[0]
-                            }
-                        </span>
-                        <span className="rounded-sm bg-orange-400 p-1 text-xs font-semibold">
-                            {pathExclusion.user.username}
-                        </span>
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+                <div className="bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
+                    <div className="mr-1 flex-1 items-start text-left">
+                        <div className="flex w-full flex-col gap-1">
+                            <div className="flex items-center justify-between text-sm">
+                                <span className="font-semibold">
+                                    {
+                                        new Date(pathExclusion.updatedAt)
+                                            .toISOString()
+                                            .split("T")[0]
+                                    }
+                                </span>
+                                <span className="rounded-sm bg-orange-400 p-1 text-xs font-semibold">
+                                    {pathExclusion.user.username}
+                                </span>
+                            </div>
+                            <FormField
+                                control={form.control}
+                                name="pattern"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="mr-1 text-xs font-semibold">
+                                            Glob pattern:
+                                        </FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                className="text-xs"
+                                                placeholder="Glob pattern matching to the path to be excluded..."
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="reason"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="mr-1 text-xs font-semibold">
+                                            Reason:
+                                        </FormLabel>
+                                        <Select
+                                            onValueChange={field.onChange}
+                                            defaultValue={field.value}
+                                        >
+                                            <FormControl>
+                                                <SelectTrigger className="text-xs">
+                                                    <SelectValue placeholder="Select a valid reason..." />
+                                                </SelectTrigger>
+                                            </FormControl>
+                                            <SelectContent>
+                                                {validReasons.map((reason) => (
+                                                    <SelectItem
+                                                        className="text-xs"
+                                                        key={reason}
+                                                        value={reason}
+                                                        onSelect={() =>
+                                                            field.onChange(
+                                                                reason,
+                                                            )
+                                                        }
+                                                    >
+                                                        {reason}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="comment"
+                                render={({ field }) => (
+                                    <FormItem className="text-muted-foreground">
+                                        <FormLabel className="mr-1 text-xs font-semibold">
+                                            Comment:
+                                        </FormLabel>
+                                        <FormControl>
+                                            <Textarea
+                                                className="text-xs"
+                                                placeholder="Comment..."
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            {form.formState.errors.root && (
+                                <div
+                                    className="relative rounded-md border border-red-400 bg-red-100 px-4 py-3 text-sm text-red-700"
+                                    role="alert"
+                                >
+                                    <span className="block sm:inline">
+                                        {form.formState.errors.root?.message}
+                                    </span>
+                                </div>
+                            )}
+                        </div>
                     </div>
-                    <div className="text-xs">
-                        <span className="mr-1 font-semibold">
-                            Glob pattern:
-                        </span>
-                        <span className="rounded-sm bg-slate-200 dark:bg-slate-600">
-                            {pathExclusion.pattern}
-                        </span>
-                    </div>
-                    <div className="text-xs">
-                        <span className="mr-1 font-semibold">Reason:</span>
-                        <span>{pathExclusion.reason}</span>
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                        <span className="mr-1 font-semibold">Comment:</span>
-                        <span className="italic">{pathExclusion.comment}</span>
+                    <div className="flex pl-1">
+                        <div className="flex items-center">
+                            <Separator
+                                orientation="vertical"
+                                className="w-[2px]"
+                            />
+                            {isLoading ? (
+                                <Loader2 className="ml-2 mr-1 h-10 w-10 animate-spin" />
+                            ) : (
+                                <Button
+                                    variant="outline"
+                                    type="submit"
+                                    className="ml-2 mr-1 px-2"
+                                >
+                                    <Check
+                                        size={16}
+                                        className="text-green-400"
+                                    />
+                                </Button>
+                            )}
+                            <Button
+                                variant="outline"
+                                className="px-2"
+                                onClick={() => editHandler(-1)}
+                            >
+                                <X size={16} className="text-[#ff3366]" />
+                            </Button>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div className="flex pl-1">
-                <div className="flex items-center">
-                    <Separator orientation="vertical" className="w-[2px]" />
-                    <Button variant="outline" className="ml-2 mr-1 px-2">
-                        <Check size={16} className="text-green-400" />
-                    </Button>
-                    <Button
-                        variant="outline"
-                        className="px-2"
-                        onClick={() => editHandler(-1)}
-                    >
-                        <X size={16} className="text-[#ff3366]" />
-                    </Button>
-                </div>
-            </div>
-        </div>
+            </form>
+        </Form>
     );
 };
 
-export default PathExclusion;
+export default PathExclusionEditForm;

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
@@ -51,8 +51,6 @@ const PathExclusionWrapper = ({ purl }: Props) => {
                             <PathExclusionEditForm
                                 key={`edit-pe-${pe.id}`}
                                 pathExclusion={pe}
-                                userName={userName}
-                                userRole={userRole}
                                 editHandler={editHandler}
                             />
                         ) : (

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
@@ -2,31 +2,35 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React from "react";
+import React, { useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
-import DeletePathExclusion from "@/components/delete_item/DeletePathExclusion";
-import EditButton from "@/components/edit_item/EditButton";
 import PathExclusion from "@/components/main_ui/package_path_exclusions/PathExclusion";
+import PathExclusionEditForm from "@/components/main_ui/package_path_exclusions/PathExclusionEditForm";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
 
 type Props = {
     purl: string;
 };
 
-const PackagePathExclusions = ({ purl }: Props) => {
+const PathExclusionWrapper = ({ purl }: Props) => {
     const pathPurl = toPathPurl(purl);
     const { data, isLoading, error } = userHooks.useGetPathExclusionsByPurl(
         { withCredentials: true, params: { purl: pathPurl } },
         { enabled: !!pathPurl },
     );
+    const [editing, setEditing] = useState(-1);
 
     // Get user from useUser hook, to decide what DB rights the user has for curations
     let user = undefined;
     user = useUser();
     const userName = user ? user.username : "Guest";
     const userRole = user ? user.role : "";
+
+    const editHandler = (id: number) => {
+        setEditing(id);
+    };
 
     return (
         <>
@@ -42,17 +46,29 @@ const PackagePathExclusions = ({ purl }: Props) => {
             )}
             {data && (
                 <div className="w-full flex-1 overflow-y-auto border">
-                    {data.pathExclusions.map((pe) => (
-                        <PathExclusion
-                            pathExclusion={pe}
-                            userName={userName}
-                            userRole={userRole}
-                        />
-                    ))}
+                    {data.pathExclusions.map((pe) =>
+                        pe.id === editing ? (
+                            <PathExclusionEditForm
+                                key={`edit-pe-${pe.id}`}
+                                pathExclusion={pe}
+                                userName={userName}
+                                userRole={userRole}
+                                editHandler={editHandler}
+                            />
+                        ) : (
+                            <PathExclusion
+                                key={`pe-${pe.id}`}
+                                pathExclusion={pe}
+                                userName={userName}
+                                userRole={userRole}
+                                editHandler={editHandler}
+                            />
+                        ),
+                    )}
                 </div>
             )}
         </>
     );
 };
 
-export default PackagePathExclusions;
+export default PathExclusionWrapper;

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
@@ -44,7 +44,7 @@ const PathExclusionWrapper = ({ purl }: Props) => {
                     <div>Error: {error.message}</div>
                 </div>
             )}
-            {data && (
+            {data && data.pathExclusions.length > 0 ? (
                 <div className="w-full flex-1 overflow-y-auto border">
                     {data.pathExclusions.map((pe) =>
                         pe.id === editing ? (
@@ -63,6 +63,10 @@ const PathExclusionWrapper = ({ purl }: Props) => {
                             />
                         ),
                     )}
+                </div>
+            ) : (
+                <div className="flex h-full items-center justify-center border">
+                    No path exclusions created for this package
                 </div>
             )}
         </>

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionWrapper.tsx
@@ -6,6 +6,9 @@ import React from "react";
 import { Loader2 } from "lucide-react";
 import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
+import DeletePathExclusion from "@/components/delete_item/DeletePathExclusion";
+import EditButton from "@/components/edit_item/EditButton";
+import PathExclusion from "@/components/main_ui/package_path_exclusions/PathExclusion";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
 
 type Props = {
@@ -38,22 +41,14 @@ const PackagePathExclusions = ({ purl }: Props) => {
                 </div>
             )}
             {data && (
-                <div className="flex-1 border p-2">
+                <div className="w-full flex-1 overflow-y-auto border">
                     {data.pathExclusions.map((pe) => (
-                        <div key={pe.id}>
-                            <div>
-                                {
-                                    new Date(pe.updatedAt)
-                                        .toISOString()
-                                        .split("T")[0]
-                                }
-                            </div>
-                            <div>{pe.pattern}</div>
-                            <div>{pe.reason}</div>
-                            <div>{pe.comment}</div>
-                        </div>
+                        <PathExclusion
+                            pathExclusion={pe}
+                            userName={userName}
+                            userRole={userRole}
+                        />
                     ))}
-                    ;
                 </div>
             )}
         </>

--- a/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
+++ b/apps/clearance_ui/src/components/package_inspector/PackageTree.tsx
@@ -24,7 +24,6 @@ import {
 } from "@/components/ui/tooltip";
 import LicenseSelector from "@/components/package_inspector/LicenseSelector";
 import Node from "@/components/package_inspector/Node";
-import ExclusionDB from "@/components/path_exclusions/ExclusionDB";
 import ExclusionTools from "@/components/path_exclusions/ExclusionTools";
 import { convertJsonToTree } from "@/helpers/convertJsonToTree";
 import { decomposeLicenses } from "@/helpers/decomposeLicenses";
@@ -323,7 +322,6 @@ const PackageTree = ({ purl, path }: Props) => {
                     filterString={"licenseFilter"}
                     className="mb-1 w-full"
                 />
-                <ExclusionDB purl={purl} fractionalWidth={1.5} />
             </div>
         </div>
     );

--- a/apps/clearance_ui/src/components/path_exclusions/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/path_exclusions/ExclusionForm.tsx
@@ -72,6 +72,9 @@ const ExclusionForm = ({
     const keyPathExclusionsByPurl = userHooks.getKeyByAlias(
         "GetPathExclusionsByPurl",
     );
+    const keyPathExclusionCountByPurl = userHooks.getKeyByAlias(
+        "GetPathExclusionsCount",
+    );
     const queryClient = useQueryClient();
 
     const { mutate: addPathExclusion } = userHooks.usePostPathExclusion(
@@ -88,8 +91,9 @@ const ExclusionForm = ({
                     title: "Path exclusion",
                     description: "Path exclusion added successfully.",
                 });
-                // When a path exclusions is added, invalidate the query to refetch the data
+                // When a path exclusion is added, invalidate the corresponding queries to refetch the data
                 queryClient.invalidateQueries(keyPathExclusionsByPurl);
+                queryClient.invalidateQueries(keyPathExclusionCountByPurl);
             },
             onError: (error) => {
                 if (axios.isAxiosError(error)) {
@@ -129,7 +133,7 @@ const ExclusionForm = ({
                     description:
                         "Path exclusion edited and saved successfully.",
                 });
-                // When a path exclusions is edited, invalidate the query to refetch the data
+                // When a path exclusion is edited, invalidate the corresponding queries to refetch the data
                 queryClient.invalidateQueries(keyPathExclusionsByPurl);
             },
             onError: (error) => {

--- a/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
@@ -5,8 +5,9 @@
 import React from "react";
 import { useRouter } from "next/router";
 import ClearanceToolbar from "@/components/ClearanceToolbar";
+import PackagePathExclusions from "@/components/main_ui/package_path_exclusions/PackagePathExclusions";
 
-const PackagePathExclusions = () => {
+const PathExclusions = () => {
     const router = useRouter();
     const purl = router.query.purl;
 
@@ -20,11 +21,9 @@ const PackagePathExclusions = () => {
     return (
         <div className="flex h-full flex-col">
             <ClearanceToolbar />
-            <div className="flex-1 border p-2">
-                Path exclusions of the package: {purl}
-            </div>
+            <PackagePathExclusions purl={purl} />
         </div>
     );
 };
 
-export default PackagePathExclusions;
+export default PathExclusions;

--- a/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { useRouter } from "next/router";
 import ClearanceToolbar from "@/components/ClearanceToolbar";
-import PackagePathExclusions from "@/components/main_ui/package_path_exclusions/PackagePathExclusions";
+import PackagePathExclusions from "@/components/main_ui/package_path_exclusions/PathExclusionWrapper";
 
 const PathExclusions = () => {
     const router = useRouter();

--- a/apps/clearance_ui/tests/e2e/logged-as-test-user/path-exclusion.spec.ts
+++ b/apps/clearance_ui/tests/e2e/logged-as-test-user/path-exclusion.spec.ts
@@ -10,10 +10,16 @@ test.beforeEach(async ({ page }) => {
     await page.goto("/packages/pkg%3Ageneric%2Fdos-monorepo%400.0.0");
 });
 
-test("create path exclusion, delete from Main UI", async ({ page }) => {
+test("create path exclusion, edit, and delete from Main UI", async ({
+    page,
+}) => {
     const pattern = "apps/api/src/**";
     const reason = "OTHER";
-    const comment = "Test create path exclusion, delete from Main UI";
+    const comment =
+        "Test create license conclusion, edit it, and finally delete from Main UI";
+    const editedReason = "OPTIONAL_COMPONENT_OF";
+    const editedComment = "Edited test comment";
+    const editedPattern = "**/*.json";
 
     // Create a path exclusion
     await page.getByText("apps").click();
@@ -23,8 +29,8 @@ test("create path exclusion, delete from Main UI", async ({ page }) => {
     await expect(page.getByLabel("Pattern")).toHaveValue(pattern);
     await page.getByLabel("Reason").click();
     await page.getByLabel(reason).click();
-    await page.getByLabel("Comment").click();
-    await page.getByLabel("Comment").fill(comment);
+    await page.getByPlaceholder("Comment...").click();
+    await page.getByPlaceholder("Comment...").fill(comment);
     await page.getByRole("button", { name: "Submit" }).click();
     // Wait for the toast to appear, contain a success text and disappear
     const toastCreated = page.getByRole("status").first();
@@ -35,19 +41,46 @@ test("create path exclusion, delete from Main UI", async ({ page }) => {
     await toastCreated.waitFor({ state: "hidden" });
     console.log("path exclusion created");
 
-    // Delete the same exclusion
-    await page
-        .locator("button")
-        .filter({ hasText: "List/delete path exclusions" })
-        .click();
+    // Edit the path exclusion
+    await page.getByRole("link", { name: "Path Exclusions" }).click();
     await page
         .getByTestId("path-exclusion")
         .filter({ hasText: comment })
+        .getByRole("button", { name: "edit" })
+        .click();
+    await page.getByLabel("Pattern").click();
+    await page.getByLabel("Pattern").fill(editedPattern);
+    await page.getByLabel("Reason").click();
+    await page.getByLabel(editedReason).click();
+    await page.getByPlaceholder("Comment...").click();
+    await page.getByPlaceholder("Comment...").fill(editedComment);
+    await page.getByTestId("path-exclusion-edit").click();
+    // Wait for the toast to appear, contain a success text and disappear
+    const toastEdited = page.getByRole("status").first();
+    await toastEdited.waitFor({ state: "visible" });
+    await expect(toastEdited).toContainText(
+        "Path exclusion edited and saved successfully.",
+    );
+    await toastCreated.waitFor({ state: "hidden" });
+    console.log("path exclusion edited");
+
+    // Check and delete the edited path exclusion
+    await expect(
+        page.getByTestId("path-exclusion").filter({ hasText: editedComment }),
+    ).toContainText(editedPattern);
+    await expect(
+        page.getByTestId("path-exclusion").filter({ hasText: editedComment }),
+    ).toContainText(editedReason);
+    await expect(
+        page.getByTestId("path-exclusion").filter({ hasText: editedComment }),
+    ).toContainText(editedComment);
+    await page
+        .getByTestId("path-exclusion")
+        .filter({ hasText: editedComment })
         .getByTestId("delete-clearance-button")
         .click();
-    await expect(page.getByLabel("Delete")).toContainText(pattern);
+    await expect(page.getByLabel("Delete")).toContainText(editedPattern);
     await page.getByRole("button", { name: "Delete" }).click();
-
     // Wait for the toast to appear, contain a success text and disappear
     const toastDeleted = page.getByRole("status").first();
     await toastDeleted.waitFor({ state: "visible" });
@@ -55,6 +88,7 @@ test("create path exclusion, delete from Main UI", async ({ page }) => {
         "Path exclusion deleted successfully.",
     );
     await toastDeleted.waitFor({ state: "hidden" });
+    await page.getByRole("link", { name: "Inspect" }).click();
     console.log("path exclusion deleted from Main UI");
 });
 
@@ -101,88 +135,4 @@ test("create path exclusion, delete from Clearance Library", async ({
     );
     await toastDeleted.waitFor({ state: "hidden" });
     console.log("path exclusion deleted from Clearance Library");
-});
-
-test("create path exclusion, edit, and delete from Main UI", async ({
-    page,
-}) => {
-    const pattern = "apps/api/src/**";
-    const reason = "OTHER";
-    const comment =
-        "Test create license conclusion, edit it, and finally delete from Main UI";
-    const editedReason = "OPTIONAL_COMPONENT_OF";
-    const editedComment = "Edited test comment";
-    const editedPattern = "**/*.json";
-
-    // Create a path exclusion
-    await page.getByText("apps").click();
-    await page.getByText("api").click();
-    await page.getByText("src").click();
-    await page.getByTestId("path-exclusion-subdirs").click();
-    await expect(page.getByLabel("Pattern")).toHaveValue(pattern);
-    await page.getByLabel("Reason").click();
-    await page.getByLabel(reason).click();
-    await page.getByPlaceholder("Comment...").click();
-    await page.getByPlaceholder("Comment...").fill(comment);
-    await page.getByRole("button", { name: "Submit" }).click();
-    // Wait for the toast to appear, contain a success text and disappear
-    const toastCreated = page.getByRole("status").first();
-    await toastCreated.waitFor({ state: "visible" });
-    await expect(toastCreated).toContainText(
-        "Path exclusion added successfully.",
-    );
-    await toastCreated.waitFor({ state: "hidden" });
-    console.log("path exclusion created");
-
-    // Edit the path exclusion
-    await page
-        .locator("button")
-        .filter({ hasText: "List/delete path exclusions" })
-        .click();
-    await page
-        .getByTestId("path-exclusion")
-        .filter({ hasText: comment })
-        .getByRole("button", { name: "edit" })
-        .click();
-    await page.getByLabel("Pattern").click();
-    await page.getByLabel("Pattern").fill(editedPattern);
-    await page.getByLabel("Reason").click();
-    await page.getByLabel(editedReason).click();
-    await page.getByPlaceholder("Comment...").click();
-    await page.getByPlaceholder("Comment...").fill(editedComment);
-    await page.getByRole("button", { name: "Submit" }).click();
-    // Wait for the toast to appear, contain a success text and disappear
-    const toastEdited = page.getByRole("status").first();
-    await toastEdited.waitFor({ state: "visible" });
-    await expect(toastEdited).toContainText(
-        "Path exclusion edited and saved successfully.",
-    );
-    await toastCreated.waitFor({ state: "hidden" });
-    console.log("path exclusion edited");
-
-    // Check and delete the edited path exclusion
-    await expect(
-        page.getByTestId("path-exclusion").filter({ hasText: editedComment }),
-    ).toContainText(editedPattern);
-    await expect(
-        page.getByTestId("path-exclusion").filter({ hasText: editedComment }),
-    ).toContainText(editedReason);
-    await expect(
-        page.getByTestId("path-exclusion").filter({ hasText: editedComment }),
-    ).toContainText(editedComment);
-    await page
-        .getByTestId("path-exclusion")
-        .filter({ hasText: editedComment })
-        .getByTestId("delete-clearance-button")
-        .click();
-    await expect(page.getByLabel("Delete")).toContainText(editedPattern);
-    await page.getByRole("button", { name: "Delete" }).click();
-    // Wait for the toast to appear, contain a success text and disappear
-    const toastDeleted = page.getByRole("status").first();
-    await toastDeleted.waitFor({ state: "visible" });
-    await expect(toastDeleted).toContainText(
-        "Path exclusion deleted successfully.",
-    );
-    await toastDeleted.waitFor({ state: "hidden" });
-    console.log("path exclusion deleted from Main UI");
 });


### PR DESCRIPTION
This PR refactors the Main UI by moving the listing, editing and deletion of package's path exclusions into a corresponding tab of the clearance toolbar.

Also resolves DO-548, as the clearance item counts are now seen in the corresponding tabs.