### PR TITLE
Do 574 show affected files for path exclusions

### DIFF
--- a/apps/clearance_ui/src/components/clearance_library/path_exclusions/columns.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/path_exclusions/columns.tsx
@@ -23,8 +23,8 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "@/components/ui/tooltip";
-import AffectedFilesTooltip from "@/components/clearance_library/path_exclusions/AffectedFilesTooltip";
 import DeletePathExclusion from "@/components/common/delete_item/DeletePathExclusion";
+import PEAffectedFilesTooltip from "@/components/common/PEAffectedFilesTooltip";
 import PurlDetails from "@/components/common/PurlDetails";
 
 type User = ZodiosResponseByPath<typeof userAPI, "get", "/user">;
@@ -342,7 +342,7 @@ export const columns = (
             ),
             cell: ({ row }) => {
                 return (
-                    <AffectedFilesTooltip pathExclusionId={row.original.id} />
+                    <PEAffectedFilesTooltip pathExclusionId={row.original.id} />
                 );
             },
         },

--- a/apps/clearance_ui/src/components/common/PEAffectedFilesTooltip.tsx
+++ b/apps/clearance_ui/src/components/common/PEAffectedFilesTooltip.tsx
@@ -16,7 +16,7 @@ type Props = {
     pathExclusionId: number;
 };
 
-const AffectedFilesTooltip = ({ pathExclusionId }: Props) => {
+const PEAffectedFilesTooltip = ({ pathExclusionId }: Props) => {
     const { data, isLoading, error } =
         userHooks.useGetAffectedFilesForPathExclusion({
             withCredentials: true,
@@ -68,4 +68,4 @@ const AffectedFilesTooltip = ({ pathExclusionId }: Props) => {
     );
 };
 
-export default AffectedFilesTooltip;
+export default PEAffectedFilesTooltip;

--- a/apps/clearance_ui/src/components/common/PEAffectedFilesTooltip.tsx
+++ b/apps/clearance_ui/src/components/common/PEAffectedFilesTooltip.tsx
@@ -50,12 +50,12 @@ const PEAffectedFilesTooltip = ({ pathExclusionId }: Props) => {
                 <TooltipProvider>
                     <Tooltip delayDuration={300}>
                         <TooltipTrigger>
-                            <Badge className="bg-blue-400 text-sm">
+                            <Badge className="bg-blue-400 text-xs">
                                 {data.affectedFiles.length}
                             </Badge>
                         </TooltipTrigger>
                         <TooltipContent>
-                            <div className="text-sm">
+                            <div className="max-h-[40vh] max-w-[50vh] overflow-y-auto text-xs">
                                 {data.affectedFiles.map((aff, index) => (
                                     <div key={index}>{aff}</div>
                                 ))}

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { ZodiosResponseByAlias } from "@zodios/core";
 import { userAPI } from "validation-helpers";
 import { Separator } from "@/components/ui/separator";
+import AffectedFilesTooltip from "@/components/clearance_library/path_exclusions/AffectedFilesTooltip";
 import DeletePathExclusion from "@/components/common/delete_item/DeletePathExclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
 
@@ -65,6 +66,16 @@ const PathExclusion = ({
                             Comment:
                         </div>
                         <div className="italic">{pathExclusion.comment}</div>
+                    </div>
+                    <div className="flex text-xs">
+                        <div className="mr-2 flex whitespace-nowrap font-semibold">
+                            Files affected by this path exclusion:
+                        </div>
+                        <div>
+                            <AffectedFilesTooltip
+                                pathExclusionId={pathExclusion.id}
+                            />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusion.tsx
@@ -6,9 +6,9 @@ import React from "react";
 import { ZodiosResponseByAlias } from "@zodios/core";
 import { userAPI } from "validation-helpers";
 import { Separator } from "@/components/ui/separator";
-import AffectedFilesTooltip from "@/components/clearance_library/path_exclusions/AffectedFilesTooltip";
 import DeletePathExclusion from "@/components/common/delete_item/DeletePathExclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
+import PEAffectedFilesTooltip from "@/components/common/PEAffectedFilesTooltip";
 
 type PathExclusion = ZodiosResponseByAlias<
     typeof userAPI,
@@ -72,7 +72,7 @@ const PathExclusion = ({
                             Files affected by this path exclusion:
                         </div>
                         <div>
-                            <AffectedFilesTooltip
+                            <PEAffectedFilesTooltip
                                 pathExclusionId={pathExclusion.id}
                             />
                         </div>


### PR DESCRIPTION
This PR adds some styling and accessibility features to the component showing the affected files for path exclusions.  The component is taken into use also for the package path exclusion list.