### PR TITLE
Do 573 group clearance items according to context purl

### DIFF
--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
@@ -17,6 +17,7 @@ type BulkConclusion = ZodiosResponseByAlias<
 >["bulkConclusions"][0];
 
 type Props = {
+    purl?: string;
     bulkConclusion: BulkConclusion;
     userName: string;
     userRole: string;
@@ -24,6 +25,7 @@ type Props = {
 };
 
 const BulkConclusion = ({
+    purl,
     bulkConclusion,
     userName,
     userRole,
@@ -83,11 +85,20 @@ const BulkConclusion = ({
                             Files affected in this package:
                         </div>
                         <div>
-                            <BCAffectedFilesTooltip
-                                bulkConclusionId={bulkConclusion.id}
-                                mode="context"
-                                badgeStyle="bg-blue-400 text-xs"
-                            />
+                            {bulkConclusion.package.purl === purl ? (
+                                <BCAffectedFilesTooltip
+                                    bulkConclusionId={bulkConclusion.id}
+                                    mode="context"
+                                    badgeStyle="bg-blue-400 text-xs"
+                                />
+                            ) : (
+                                <BCAffectedFilesTooltip
+                                    bulkConclusionId={bulkConclusion.id}
+                                    mode="query"
+                                    queryPurl={purl}
+                                    badgeStyle="bg-orange-400 text-xs"
+                                />
+                            )}
                         </div>
                     </div>
                     {bulkConclusion.local && (

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import BCAffectedFilesTooltip from "@/components/common/BCAffectedFilesTooltip";
 import DeleteBulkConclusion from "@/components/common/delete_item/DeleteBulkConclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
+import PurlDetails from "@/components/common/PurlDetails";
 
 type BulkConclusion = ZodiosResponseByAlias<
     typeof userAPI,
@@ -66,12 +67,14 @@ const BulkConclusion = ({
                             {bulkConclusion.pattern}
                         </div>
                     </div>
-                    <div className="flex text-xs">
-                        <div className="mr-2 flex whitespace-nowrap font-semibold">
-                            Context purl:
-                        </div>
-                        <div className="break-all">
-                            {bulkConclusion.package.purl}
+                    <div className="text-xs">
+                        <div className="mr-2 font-semibold">Context purl:</div>
+                        <div className="ml-9">
+                            <PurlDetails
+                                purl={bulkConclusion.package.purl}
+                                hideBorder={true}
+                                hideCopyToClipboard={true}
+                            />
                         </div>
                     </div>
                     <div className="text-muted-foreground flex text-xs">

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
@@ -5,12 +5,11 @@
 import React from "react";
 import { ZodiosResponseByAlias } from "@zodios/core";
 import { userAPI } from "validation-helpers";
-import { userHooks } from "@/hooks/zodiosHooks";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import BCAffectedFilesTooltip from "@/components/common/BCAffectedFilesTooltip";
 import DeleteBulkConclusion from "@/components/common/delete_item/DeleteBulkConclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
-import { findMatchingPaths } from "@/helpers/findMatchingPaths";
 
 type BulkConclusion = ZodiosResponseByAlias<
     typeof userAPI,
@@ -18,7 +17,6 @@ type BulkConclusion = ZodiosResponseByAlias<
 >["bulkConclusions"][0];
 
 type Props = {
-    pathPurl: string;
     bulkConclusion: BulkConclusion;
     userName: string;
     userRole: string;
@@ -26,25 +24,11 @@ type Props = {
 };
 
 const BulkConclusion = ({
-    pathPurl,
     bulkConclusion,
     userName,
     userRole,
     editHandler,
 }: Props) => {
-    // Fetch the package file tree data
-    const { data: fileTreeData } = userHooks.useGetFileTree({
-        withCredentials: true,
-        params: {
-            purl: pathPurl,
-        },
-    });
-    const paths =
-        fileTreeData?.filetrees.map((filetree) => filetree.path) || [];
-    const pathsMatching = bulkConclusion.pattern
-        ? findMatchingPaths(paths, bulkConclusion.pattern)
-        : [];
-
     return (
         <div
             className="hover:bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2"
@@ -99,9 +83,11 @@ const BulkConclusion = ({
                             Files affected in this package:
                         </div>
                         <div>
-                            <Badge className="bg-blue-400 p-0.5 font-bold">
-                                {pathsMatching.length}
-                            </Badge>
+                            <BCAffectedFilesTooltip
+                                bulkConclusionId={bulkConclusion.id}
+                                mode="context"
+                                badgeStyle="bg-blue-400 text-xs"
+                            />
                         </div>
                     </div>
                     {bulkConclusion.local && (

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusion.tsx
@@ -31,7 +31,7 @@ const BulkConclusion = ({
 }: Props) => {
     return (
         <div
-            className="hover:bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2"
+            className="hover:bg-muted m-2 ml-12 flex items-stretch justify-between rounded-lg border p-2"
             data-testid="bulk-conclusion"
         >
             <div className="mr-1 flex-1 items-start text-left">

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
@@ -57,7 +57,6 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
                         ) : (
                             <BulkConclusion
                                 key={`bc-${bc.id}`}
-                                pathPurl={pathPurl}
                                 bulkConclusion={bc}
                                 userName={userName}
                                 userRole={userRole}

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
@@ -32,6 +32,15 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
         setEditing(id);
     };
 
+    // Filter the data (bulk conclusions) into two sublists,
+    // one for BCs in this package and one for BCs in other packages
+    const bcForThisPackage = data?.bulkConclusions.filter(
+        (bc) => bc.package.purl === purl,
+    );
+    const bcForOtherContext = data?.bulkConclusions.filter(
+        (bc) => bc.package.purl !== purl,
+    );
+
     return (
         <>
             {isLoading && (

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
@@ -113,8 +113,8 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
                                         packages and/or other versions of this
                                         package. These bulk conclusions are
                                         relevant for this package and thus shown
-                                        here, because because the SHA256 (ie.
-                                        contents) of the files match.
+                                        here, because the SHA256 (ie. contents)
+                                        of the files match.
                                     </CardDescription>
                                 </CardHeader>
                             </Card>

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
@@ -88,6 +88,7 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
                                 ) : (
                                     <BulkConclusion
                                         key={`bc-${bc.id}`}
+                                        purl={purl}
                                         bulkConclusion={bc}
                                         userName={userName}
                                         userRole={userRole}
@@ -112,8 +113,8 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
                                         packages and/or other versions of this
                                         package. These bulk conclusions are
                                         relevant for this package and thus shown
-                                        here, because the glob pattern of the
-                                        concluded files matches.
+                                        here, because because the SHA256 (ie.
+                                        contents) of the files match.
                                     </CardDescription>
                                 </CardHeader>
                             </Card>
@@ -128,6 +129,7 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
                                 ) : (
                                     <BulkConclusion
                                         key={`bc-${bc.id}`}
+                                        purl={purl}
                                         bulkConclusion={bc}
                                         userName={userName}
                                         userRole={userRole}

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper.tsx
@@ -6,6 +6,12 @@ import React, { useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
+import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
 import BulkConclusion from "@/components/main_ui/package_bulk_conclusions/BulkConclusion";
 import BulkConclusionEditForm from "@/components/main_ui/package_bulk_conclusions/BulkConclusionEditForm";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
@@ -55,23 +61,81 @@ const BulkConclusionWrapper = ({ purl }: Props) => {
             )}
             {data && data.bulkConclusions.length > 0 ? (
                 <div className="w-full flex-1 overflow-y-auto border">
-                    {data.bulkConclusions.map((bc) =>
-                        bc.id === editing ? (
-                            <BulkConclusionEditForm
-                                key={`edit-bc-${bc.id}`}
-                                pathPurl={pathPurl}
-                                bulkConclusion={bc}
-                                editHandler={editHandler}
-                            />
-                        ) : (
-                            <BulkConclusion
-                                key={`bc-${bc.id}`}
-                                bulkConclusion={bc}
-                                userName={userName}
-                                userRole={userRole}
-                                editHandler={editHandler}
-                            />
-                        ),
+                    {bcForThisPackage && bcForThisPackage.length > 0 && (
+                        <>
+                            <Card className="bg-muted m-2">
+                                <CardHeader>
+                                    <CardTitle>
+                                        Bulk Conclusions created for this
+                                        package
+                                    </CardTitle>
+                                    <CardDescription>
+                                        This is a list of the{" "}
+                                        {bcForThisPackage?.length} bulk
+                                        conclusions that are created originally
+                                        for this package and version.
+                                    </CardDescription>
+                                </CardHeader>
+                            </Card>
+                            {bcForThisPackage.map((bc) =>
+                                bc.id === editing ? (
+                                    <BulkConclusionEditForm
+                                        key={`edit-bc-${bc.id}`}
+                                        pathPurl={pathPurl}
+                                        bulkConclusion={bc}
+                                        editHandler={editHandler}
+                                    />
+                                ) : (
+                                    <BulkConclusion
+                                        key={`bc-${bc.id}`}
+                                        bulkConclusion={bc}
+                                        userName={userName}
+                                        userRole={userRole}
+                                        editHandler={editHandler}
+                                    />
+                                ),
+                            )}
+                        </>
+                    )}
+                    {bcForOtherContext && bcForOtherContext.length > 0 && (
+                        <>
+                            <Card className="bg-muted m-2">
+                                <CardHeader>
+                                    <CardTitle>
+                                        Bulk Conclusions created for other
+                                        packages
+                                    </CardTitle>
+                                    <CardDescription>
+                                        There are additionally a total of{" "}
+                                        {bcForOtherContext?.length} bulk
+                                        conclusions that are created for other
+                                        packages and/or other versions of this
+                                        package. These bulk conclusions are
+                                        relevant for this package and thus shown
+                                        here, because the glob pattern of the
+                                        concluded files matches.
+                                    </CardDescription>
+                                </CardHeader>
+                            </Card>
+                            {bcForOtherContext.map((bc) =>
+                                bc.id === editing ? (
+                                    <BulkConclusionEditForm
+                                        key={`edit-bc-${bc.id}`}
+                                        pathPurl={pathPurl}
+                                        bulkConclusion={bc}
+                                        editHandler={editHandler}
+                                    />
+                                ) : (
+                                    <BulkConclusion
+                                        key={`bc-${bc.id}`}
+                                        bulkConclusion={bc}
+                                        userName={userName}
+                                        userRole={userRole}
+                                        editHandler={editHandler}
+                                    />
+                                ),
+                            )}
+                        </>
                     )}
                 </div>
             ) : (

--- a/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusion.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import DeleteLicenseConclusion from "@/components/common/delete_item/DeleteLicenseConclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
+import PurlDetails from "@/components/common/PurlDetails";
 import AffectedPath from "@/components/main_ui/package_license_conclusions/AffectedPath";
 
 type LicenseConclusion = ZodiosResponseByAlias<
@@ -67,12 +68,14 @@ const LicenseConclusion = ({
                                 "No detected license"}
                         </div>
                     </div>
-                    <div className="flex text-xs">
-                        <div className="mr-2 flex whitespace-nowrap font-semibold">
-                            Context PURL:
-                        </div>
-                        <div className="break-all">
-                            {licenseConclusion.contextPurl}
+                    <div className="text-xs">
+                        <div className="mr-2 font-semibold">Context PURL:</div>
+                        <div className="ml-9">
+                            <PurlDetails
+                                purl={licenseConclusion.contextPurl}
+                                hideBorder={true}
+                                hideCopyToClipboard={true}
+                            />
                         </div>
                     </div>
                     <div className="text-xs">

--- a/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusion.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusion.tsx
@@ -33,7 +33,7 @@ const LicenseConclusion = ({
 }: Props) => {
     return (
         <div
-            className="hover:bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2"
+            className="hover:bg-muted m-2 ml-12 flex items-stretch justify-between rounded-lg border p-2"
             data-testid="license-conclusion"
         >
             <div className="mr-1 flex-1 items-start text-left">

--- a/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusionEditForm.tsx
@@ -172,7 +172,7 @@ const LicenseConclusionEditForm = ({
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)}>
-                <div className="bg-muted m-2 flex items-stretch justify-between rounded-lg border p-2">
+                <div className="bg-muted m-2 ml-12 flex items-stretch justify-between rounded-lg border p-2">
                     <div className="mr-1 flex-1 items-start text-left">
                         <div className="flex w-full flex-col gap-1">
                             <div className="flex items-center justify-between text-sm">

--- a/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusionWrapper.tsx
@@ -35,6 +35,15 @@ const LicenseConclusionWrapper = ({ purl }: Props) => {
         setEditing(id);
     };
 
+    // Filter the data (license conclusions) into two sublists,
+    // one for LCs in this package and one for LCs in other packages
+    const lcForThisPackage = data?.licenseConclusions.filter(
+        (lc) => lc.contextPurl === purl,
+    );
+    const lcForOtherContext = data?.licenseConclusions.filter(
+        (lc) => lc.contextPurl !== purl,
+    );
+
     return (
         <>
             {isLoading && (

--- a/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusionWrapper.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_license_conclusions/LicenseConclusionWrapper.tsx
@@ -6,6 +6,12 @@ import React, { useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
+import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
 import LicenseConclusion from "@/components/main_ui/package_license_conclusions/LicenseConclusion";
 import LicenseConclusionEditForm from "@/components/main_ui/package_license_conclusions/LicenseConclusionEditForm";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
@@ -58,23 +64,81 @@ const LicenseConclusionWrapper = ({ purl }: Props) => {
             )}
             {data && data.licenseConclusions.length > 0 ? (
                 <div className="w-full flex-1 overflow-y-auto border">
-                    {data.licenseConclusions.map((lc) =>
-                        lc.id === editing ? (
-                            <LicenseConclusionEditForm
-                                key={`edit-lc-${lc.id}`}
-                                licenseConclusion={lc}
-                                editHandler={editHandler}
-                            />
-                        ) : (
-                            <LicenseConclusion
-                                key={`lc-${lc.id}`}
-                                purl={purl}
-                                licenseConclusion={lc}
-                                userName={userName}
-                                userRole={userRole}
-                                editHandler={editHandler}
-                            />
-                        ),
+                    {lcForThisPackage && lcForThisPackage.length > 0 && (
+                        <>
+                            <Card className="bg-muted m-2">
+                                <CardHeader>
+                                    <CardTitle>
+                                        License Conclusions created for this
+                                        package
+                                    </CardTitle>
+                                    <CardDescription>
+                                        This is a list of the{" "}
+                                        {lcForThisPackage?.length} license
+                                        conclusions that are created originally
+                                        for this package and version.
+                                    </CardDescription>
+                                </CardHeader>
+                            </Card>
+                            {lcForThisPackage.map((lc) =>
+                                lc.id === editing ? (
+                                    <LicenseConclusionEditForm
+                                        key={`edit-lc-${lc.id}`}
+                                        licenseConclusion={lc}
+                                        editHandler={editHandler}
+                                    />
+                                ) : (
+                                    <LicenseConclusion
+                                        key={`lc-${lc.id}`}
+                                        purl={purl}
+                                        licenseConclusion={lc}
+                                        userName={userName}
+                                        userRole={userRole}
+                                        editHandler={editHandler}
+                                    />
+                                ),
+                            )}
+                        </>
+                    )}
+                    {lcForOtherContext && lcForOtherContext.length > 0 && (
+                        <>
+                            <Card className="bg-muted m-2">
+                                <CardHeader>
+                                    <CardTitle>
+                                        License Conclusions created for other
+                                        packages
+                                    </CardTitle>
+                                    <CardDescription>
+                                        There are additionally a total of{" "}
+                                        {lcForOtherContext?.length} license
+                                        conclusions that are created for other
+                                        packages and/or other versions of this
+                                        package. These license conclusions are
+                                        relevant for this package and thus shown
+                                        here, because the SHA256 (ie. contents)
+                                        of the files match.
+                                    </CardDescription>
+                                </CardHeader>
+                            </Card>
+                            {lcForOtherContext.map((lc) =>
+                                lc.id === editing ? (
+                                    <LicenseConclusionEditForm
+                                        key={`edit-lc-${lc.id}`}
+                                        licenseConclusion={lc}
+                                        editHandler={editHandler}
+                                    />
+                                ) : (
+                                    <LicenseConclusion
+                                        key={`lc-${lc.id}`}
+                                        purl={purl}
+                                        licenseConclusion={lc}
+                                        userName={userName}
+                                        userRole={userRole}
+                                        editHandler={editHandler}
+                                    />
+                                ),
+                            )}
+                        </>
                     )}
                 </div>
             ) : (


### PR DESCRIPTION
This PR makes the license conclusion and bulk conclusion tabs clearer by separating the clearance items created for this package from clearances that are created for other packages and/or versions of this package.  

It is still necessary to see the latter items in the corresponding tabs, because we use file/SHA based - rather than package level - clearances, and as a consequence, when the file SHA matches, its corresponding clearance matches as well, whether or not it has been created for this package or not.

Also resolves DO-575 