### PR TITLE
Do 582 implement selection mode for packageinspector

### DIFF
--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useState } from "react";
+import { FiFilePlus } from "react-icons/fi";
 import { LuFileStack } from "react-icons/lu";
 import {
     TbFileOff,
@@ -12,6 +13,7 @@ import {
 } from "react-icons/tb";
 import { TfiPencil } from "react-icons/tfi";
 import { Button } from "@/components/ui/button";
+import { Toggle } from "@/components/ui/toggle";
 import {
     Tooltip,
     TooltipContent,
@@ -27,6 +29,7 @@ type Props = {
     selectedNode: SelectedNode | undefined;
     purl: string;
     className?: string;
+    onSelectionModeChange: (newValue: boolean) => void;
 };
 
 // Check if the selected node has children directories:
@@ -35,7 +38,12 @@ const hasChildrenDirs = (node: SelectedNode | undefined) => {
     return node?.children?.some((child: SelectedNode) => !child.isLeaf);
 };
 
-const ClearanceTools = ({ selectedNode, purl, className }: Props) => {
+const ClearanceTools = ({
+    selectedNode,
+    purl,
+    className,
+    onSelectionModeChange,
+}: Props) => {
     const [openDirDialog, setOpenDirDialog] = useState<boolean>(false);
     const [openSubdirsDialog, setOpenSubdirsDialog] = useState<boolean>(false);
     const [openFileDialog, setOpenFileDialog] = useState<boolean>(false);
@@ -44,6 +52,7 @@ const ClearanceTools = ({ selectedNode, purl, className }: Props) => {
         useState<boolean>(false);
     const [openBulkConclusionDialog, setOpenBulkConclusionDialog] =
         useState<boolean>(false);
+    const [isSelectionMode, setIsSelectionMode] = useState<boolean>(false);
 
     return (
         <div
@@ -208,6 +217,35 @@ const ClearanceTools = ({ selectedNode, purl, className }: Props) => {
                             open={openBulkConclusionDialog}
                             setOpen={setOpenBulkConclusionDialog}
                         />
+                    </Tooltip>
+                    <Tooltip>
+                        <div className="group relative">
+                            <TooltipTrigger asChild>
+                                <Toggle
+                                    className={
+                                        isSelectionMode
+                                            ? "border border-red-500 p-2"
+                                            : "p-2"
+                                    }
+                                    pressed={isSelectionMode}
+                                    onPressedChange={() => {
+                                        setIsSelectionMode(!isSelectionMode);
+                                        onSelectionModeChange(!isSelectionMode);
+                                    }}
+                                >
+                                    {isSelectionMode ? (
+                                        <FiFilePlus className="text-lg text-red-500" />
+                                    ) : (
+                                        <FiFilePlus className="text-lg" />
+                                    )}
+                                </Toggle>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                {isSelectionMode
+                                    ? "Toggle off selection mode"
+                                    : "Toggle selection mode to select multiple nodes from the tree"}
+                            </TooltipContent>
+                        </div>
                     </Tooltip>
                 </TooltipProvider>
             </>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useState } from "react";
-import { FiFilePlus } from "react-icons/fi";
+import { FiFileMinus, FiFilePlus } from "react-icons/fi";
 import { LuFileStack } from "react-icons/lu";
 import {
     TbFileOff,
@@ -30,6 +30,7 @@ type Props = {
     purl: string;
     className?: string;
     onSelectionModeChange: (newValue: boolean) => void;
+    onClearSelection: () => void;
 };
 
 // Check if the selected node has children directories:
@@ -43,6 +44,7 @@ const ClearanceTools = ({
     purl,
     className,
     onSelectionModeChange,
+    onClearSelection,
 }: Props) => {
     const [openDirDialog, setOpenDirDialog] = useState<boolean>(false);
     const [openSubdirsDialog, setOpenSubdirsDialog] = useState<boolean>(false);
@@ -244,6 +246,22 @@ const ClearanceTools = ({
                                 {isSelectionMode
                                     ? "Toggle off selection mode"
                                     : "Toggle selection mode to select multiple nodes from the tree"}
+                            </TooltipContent>
+                        </div>
+                    </Tooltip>
+                    <Tooltip>
+                        <div className="group relative">
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="ghost"
+                                    className="p-2"
+                                    onClick={() => onClearSelection()}
+                                >
+                                    <FiFileMinus className="text-lg" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                Clear all selections from the tree
                             </TooltipContent>
                         </div>
                     </Tooltip>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
@@ -226,8 +226,8 @@ const ClearanceTools = ({
                                 <Toggle
                                     className={
                                         isSelectionMode
-                                            ? "border border-red-500 p-2"
-                                            : "p-2"
+                                            ? "hidden border border-red-500 p-2"
+                                            : "hidden p-2"
                                     }
                                     pressed={isSelectionMode}
                                     onPressedChange={() => {
@@ -254,7 +254,7 @@ const ClearanceTools = ({
                             <TooltipTrigger asChild>
                                 <Button
                                     variant="ghost"
-                                    className="p-2"
+                                    className="hidden p-2"
                                     onClick={() => onClearSelection()}
                                 >
                                     <FiFileMinus className="text-lg" />

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
@@ -124,12 +124,13 @@ const Node = ({
                 }
             }}
         >
+            <span className="flex items-center">{icon}</span>
             {isSelectionMode && (
                 <Checkbox
                     className={
                         selectionStatus === 0.5
-                            ? "border-gray-400 bg-gray-400 p-0"
-                            : "border-gray-400 bg-white p-0"
+                            ? "ml-1 h-3.5 w-3.5 border-gray-400 bg-gray-400 p-0"
+                            : "ml-1 h-3.5 w-3.5 border-gray-400 bg-white p-0"
                     }
                     checked={selectionStatus === 1}
                     onClick={() => {
@@ -140,7 +141,7 @@ const Node = ({
                     id={id}
                 />
             )}
-            <span className="flex items-center">{icon}</span>
+
             <span className="ml-1 flex-grow truncate font-mono text-xs">
                 {isLeaf ? (
                     <Link

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
@@ -11,6 +11,7 @@ import {
     BsFolder2Open as FolderOpen,
 } from "react-icons/bs";
 import { MdArrowDropDown, MdArrowRight } from "react-icons/md";
+import { Checkbox } from "@/components/ui/checkbox";
 import LicenseHitCircle from "@/components/main_ui/inspector/package_inspector/LicenseHitCircle";
 import { cn } from "@/lib/utils";
 import type { TreeNode } from "@/types/index";
@@ -21,6 +22,9 @@ type NodeProps = NodeRendererProps<TreeNode> & {
     filtering: boolean;
     openedNodeId: string | undefined;
     uniqueLicenses: Map<string, string>;
+    isSelectionMode: boolean;
+    isSelected: boolean;
+    setIsSelected: (isSelected: boolean) => void;
 };
 
 const Node = ({
@@ -31,8 +35,11 @@ const Node = ({
     filtering,
     openedNodeId,
     uniqueLicenses,
+    isSelectionMode,
+    isSelected,
+    setIsSelected,
 }: NodeProps) => {
-    const { isLeaf, isClosed, data } = node;
+    const { id, data, isLeaf, isClosed } = node;
     const {
         hasLicenseFindings,
         hasLicenseConclusions,
@@ -89,21 +96,21 @@ const Node = ({
         icon = (
             <>
                 <span className="ml-4"></span>
-                <FileText color={color} style={isBold && boldStyle} />
+                <FileText color={color} style={isBold ? boldStyle : {}} />
             </>
         );
     } else if (isClosed) {
         icon = (
             <>
                 <MdArrowRight />
-                <FolderClosed color={color} style={isBold && boldStyle} />
+                <FolderClosed color={color} style={isBold ? boldStyle : {}} />
             </>
         );
     } else {
         icon = (
             <>
                 <MdArrowDropDown />
-                <FolderOpen color={color} style={isBold && boldStyle} />
+                <FolderOpen color={color} style={isBold ? boldStyle : {}} />
             </>
         );
     }
@@ -118,8 +125,19 @@ const Node = ({
                 }
             }}
         >
+            {isSelectionMode && (
+                <Checkbox
+                    className="p-0"
+                    checked={isSelected}
+                    onClick={() => {
+                        {
+                            setIsSelected(!isSelected);
+                        }
+                    }}
+                    id={id}
+                />
+            )}
             <span className="flex items-center">{icon}</span>
-
             <span className="ml-1 flex-grow truncate font-mono text-xs">
                 {isLeaf ? (
                     <Link

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
@@ -115,16 +115,17 @@ const Node = ({
     }
 
     return (
-        <div
-            className="flex cursor-pointer items-center"
-            style={style}
-            onClick={() => {
-                if (!isLeaf) {
-                    node.toggle();
-                }
-            }}
-        >
-            <span className="flex items-center">{icon}</span>
+        <div className="flex cursor-pointer items-center" style={style}>
+            <span
+                className="flex items-center"
+                onClick={() => {
+                    if (!isLeaf) {
+                        node.toggle();
+                    }
+                }}
+            >
+                {icon}
+            </span>
             {isSelectionMode && (
                 <Checkbox
                     className={
@@ -169,7 +170,14 @@ const Node = ({
                         </span>
                     </Link>
                 ) : (
-                    <span className="hover:bg-primary/20 inline-block w-full rounded-sm">
+                    <span
+                        onClick={() => {
+                            if (!isLeaf) {
+                                node.toggle();
+                            }
+                        }}
+                        className="hover:bg-primary/20 inline-block w-full rounded-sm"
+                    >
                         {name}
                     </span>
                 )}

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
@@ -23,7 +23,6 @@ type NodeProps = NodeRendererProps<TreeNode> & {
     openedNodeId: string | undefined;
     uniqueLicenses: Map<string, string>;
     isSelectionMode: boolean;
-    isSelected: boolean;
     setIsSelected: (isSelected: boolean) => void;
 };
 
@@ -36,7 +35,6 @@ const Node = ({
     openedNodeId,
     uniqueLicenses,
     isSelectionMode,
-    isSelected,
     setIsSelected,
 }: NodeProps) => {
     const { id, data, isLeaf, isClosed } = node;
@@ -47,6 +45,7 @@ const Node = ({
         name,
         path,
         file,
+        selectionStatus,
     } = data;
     const boldStyle = { strokeWidth: 0.5 };
     let color;
@@ -127,11 +126,15 @@ const Node = ({
         >
             {isSelectionMode && (
                 <Checkbox
-                    className="p-0"
-                    checked={isSelected}
+                    className={
+                        selectionStatus === 0.5
+                            ? "border-gray-400 bg-gray-400 p-0"
+                            : "border-gray-400 bg-white p-0"
+                    }
+                    checked={selectionStatus === 1}
                     onClick={() => {
                         {
-                            setIsSelected(!isSelected);
+                            setIsSelected(selectionStatus === 1 ? false : true);
                         }
                     }}
                     id={id}

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/router";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
-import { NodeApi, Tree, TreeApi } from "react-arborist";
+import { Tree, TreeApi } from "react-arborist";
 import { userHooks } from "@/hooks/zodiosHooks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -29,6 +29,7 @@ import { findNodeByPath } from "@/helpers/findNodeByPath";
 import { getNodesWithChildren } from "@/helpers/getNodesWithChildren";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
 import { stringToColour } from "@/helpers/stringToColour";
+import { updateSelectedNodes } from "@/helpers/treeSelectionUtils";
 import { updateHasLicenseFindings } from "@/helpers/updateHasLicenseFindings";
 import type { SelectedNode, TreeNode } from "@/types/index";
 
@@ -109,16 +110,12 @@ const PackageInspector = ({ purl, path }: Props) => {
         nodeData: TreeNode,
         isSelected: boolean,
     ): void => {
-        if (isSelected) {
-            setSelectedNodes((prevSelectedNodes: TreeNode[]) => [
-                ...prevSelectedNodes,
-                nodeData,
-            ]);
-        } else {
-            setSelectedNodes((prevSelectedNodes: TreeNode[]) =>
-                prevSelectedNodes.filter((node: TreeNode) => node !== nodeData),
-            );
-        }
+        updateSelectedNodes(
+            nodeData,
+            isSelected,
+            selectedNodes,
+            setSelectedNodes,
+        );
     };
 
     useEffect(() => {

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -58,7 +58,7 @@ const PackageInspector = ({ purl, path }: Props) => {
     const [selectedNode, setSelectedNode] = useState<SelectedNode>();
     const [openedNodeId, setOpenedNodeId] = useState<string>();
     const [isSelectionMode, setIsSelectionMode] = useState(false);
-    const [selectedNodes, setSelectedNodes] = useState<TreeNode[]>([]);
+    const [selectedNodes, setSelectedNodes] = useState<NodeApi<TreeNode>[]>([]);
     const treeRef = useRef<HTMLDivElement>(null);
 
     const router = useRouter();
@@ -188,13 +188,9 @@ const PackageInspector = ({ purl, path }: Props) => {
     }, [path, treeData, tree]);
 
     useEffect(() => {
-        console.log("Selection mode activated: ", isSelectionMode);
-    }, [isSelectionMode]);
-
-    useEffect(() => {
         console.log(
             "Selected nodes: ",
-            selectedNodes.map((node) => node.path),
+            selectedNodes.map((node) => node.data.path),
         );
     }, [selectedNodes]);
 

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/router";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
-import { Tree, TreeApi } from "react-arborist";
+import { NodeApi, Tree, TreeApi } from "react-arborist";
 import { userHooks } from "@/hooks/zodiosHooks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -107,15 +107,10 @@ const PackageInspector = ({ purl, path }: Props) => {
 
     // Update the selected nodes when a node is selected or deselected
     const handleNodeSelection = (
-        nodeData: TreeNode,
+        node: NodeApi<TreeNode>,
         isSelected: boolean,
     ): void => {
-        updateSelectedNodes(
-            nodeData,
-            isSelected,
-            selectedNodes,
-            setSelectedNodes,
-        );
+        updateSelectedNodes(node, isSelected, selectedNodes, setSelectedNodes);
     };
 
     useEffect(() => {
@@ -324,12 +319,9 @@ const PackageInspector = ({ purl, path }: Props) => {
                                 openedNodeId={openedNodeId}
                                 uniqueLicenses={uniqueLicensesToColorMap}
                                 isSelectionMode={isSelectionMode}
-                                isSelected={selectedNodes.includes(
-                                    nodeProps.node.data,
-                                )}
                                 setIsSelected={(isSelected) =>
                                     handleNodeSelection(
-                                        nodeProps.node.data,
+                                        nodeProps.node,
                                         isSelected,
                                     )
                                 }

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -53,6 +53,7 @@ const PackageInspector = ({ purl, path }: Props) => {
     const [originalTreeData, setOriginalTreeData] = useState<TreeNode[]>([]);
     const [selectedNode, setSelectedNode] = useState<SelectedNode>();
     const [openedNodeId, setOpenedNodeId] = useState<string>();
+    const [isSelectionMode, setIsSelectionMode] = useState(false);
     const treeRef = useRef<HTMLDivElement>(null);
 
     const router = useRouter();
@@ -173,6 +174,10 @@ const PackageInspector = ({ purl, path }: Props) => {
         }
     }, [path, treeData, tree]);
 
+    useEffect(() => {
+        console.log("Selection mode activated: ", isSelectionMode);
+    }, [isSelectionMode]);
+
     return (
         <div className="flex h-full flex-col">
             <div className="mb-3 flex items-center text-sm">
@@ -203,6 +208,9 @@ const PackageInspector = ({ purl, path }: Props) => {
                     selectedNode={selectedNode}
                     purl={purl}
                     className="mr-2 flex-1"
+                    onSelectionModeChange={(mode) => {
+                        setIsSelectionMode(mode);
+                    }}
                 />
                 <TooltipProvider delayDuration={300}>
                     <Tooltip>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -139,6 +139,7 @@ const PackageInspector = ({ purl, path }: Props) => {
             // Reset to original tree data if licenseFilter is empty or filtering is off
             setTreeData(originalTreeData);
             setIsExpanded(false);
+            setSelectedNodes([...selectedNodes]);
         }
     }, [licenseFilter, filtering, originalTreeData]);
 
@@ -189,10 +190,14 @@ const PackageInspector = ({ purl, path }: Props) => {
 
     useEffect(() => {
         console.log(
-            "Selected nodes: ",
+            "selected ids:",
+            selectedNodes.map((node) => node.data.id),
+        );
+        console.log(
+            "selected paths:",
             selectedNodes.map((node) => node.data.path),
         );
-    }, [selectedNodes]);
+    }, [selectedNodes, filtering]);
 
     return (
         <div className="flex h-full flex-col">

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -29,7 +29,10 @@ import { findNodeByPath } from "@/helpers/findNodeByPath";
 import { getNodesWithChildren } from "@/helpers/getNodesWithChildren";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
 import { stringToColour } from "@/helpers/stringToColour";
-import { updateSelectedNodes } from "@/helpers/treeSelectionUtils";
+import {
+    clearSelectedNodes,
+    updateSelectedNodes,
+} from "@/helpers/treeSelectionUtils";
 import { updateHasLicenseFindings } from "@/helpers/updateHasLicenseFindings";
 import type { SelectedNode, TreeNode } from "@/types/index";
 
@@ -227,9 +230,10 @@ const PackageInspector = ({ purl, path }: Props) => {
                     className="mr-2 flex-1"
                     onSelectionModeChange={(mode) => {
                         setIsSelectionMode(mode);
-                        if (!isSelectionMode) {
-                            setSelectedNodes([]);
-                        }
+                    }}
+                    onClearSelection={() => {
+                        clearSelectedNodes(selectedNodes);
+                        setSelectedNodes([]);
                     }}
                 />
                 <TooltipProvider delayDuration={300}>

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -2,30 +2,90 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { NodeApi } from "react-arborist";
 import type { TreeNode } from "@/types/index";
 
 export const updateSelectedNodes = (
-    nodeData: TreeNode,
+    node: NodeApi<TreeNode>,
     isSelected: boolean,
     selectedNodes: TreeNode[],
     setSelectedNodes: (nodes: TreeNode[]) => void,
 ) => {
+    // Helper function to recursively select or deselect nodes
+    const toggleSelectionRecursive = (
+        currentNode: NodeApi<TreeNode>,
+        select: boolean,
+    ) => {
+        // Add or remove the current node from the updatedNodes list
+        if (select && !updatedNodes.includes(currentNode.data)) {
+            updatedNodes.push(currentNode.data);
+        } else if (!select) {
+            updatedNodes = updatedNodes.filter(
+                (selectedNode) => selectedNode !== currentNode.data,
+            );
+        }
+
+        // Recursively select or deselect immediate children nodes if the current node is a directory
+        if (!currentNode.isLeaf && currentNode.children) {
+            currentNode.children.forEach((childNode) => {
+                toggleSelectionRecursive(childNode, select);
+            });
+        }
+        // Update the selection status based on the select parameter
+        currentNode.data.selectionStatus = select ? 1 : 0;
+    };
+
+    // Helper function to recursively update the parent nodes with intermediate selection status
+    const updateParentNodes = (currentNode: NodeApi<TreeNode>) => {
+        const parentNode = currentNode.parent;
+        if (parentNode) {
+            console.log("Current node: ", currentNode.data.path);
+            console.log("Parent node: ", parentNode.data.path);
+            const children = parentNode.children || [];
+            const hasSelectedOrIntermediateChild = children.some(
+                (child) =>
+                    updatedNodes.includes(child.data) ||
+                    child.data.selectionStatus === 0.5,
+            );
+
+            if (hasSelectedOrIntermediateChild) {
+                parentNode.data.selectionStatus = 0.5;
+            } else {
+                parentNode.data.selectionStatus = 0;
+            }
+            updateParentNodes(parentNode); // Recursively call updateParentNodes for the parent node
+        }
+    };
+
     let updatedNodes: TreeNode[];
 
-    if (isSelected) {
-        updatedNodes = [...selectedNodes, nodeData];
-    } else {
-        updatedNodes = selectedNodes.filter((node) => node !== nodeData);
+    updatedNodes = isSelected
+        ? [...selectedNodes, node.data]
+        : selectedNodes.filter((selectedNode) => selectedNode !== node.data);
+
+    // Recursively toggle selection of the node and its immediate descendants
+    toggleSelectionRecursive(node, isSelected);
+
+    // Check if all children of the parent node are selected or deselected,
+    // and update the parent's selection status accordingly
+    const parentNode = node.parent;
+    if (parentNode) {
+        const children = parentNode.children || [];
+        const totalChildren = children.length;
+        const selectedChildrenCount = children.filter((child) =>
+            updatedNodes.includes(child.data),
+        ).length;
+
+        if (selectedChildrenCount === 0) {
+            parentNode.data.selectionStatus = 0;
+        } else if (selectedChildrenCount === totalChildren) {
+            parentNode.data.selectionStatus = 1;
+        } else {
+            parentNode.data.selectionStatus = 0.5;
+        }
+        updateParentNodes(parentNode);
     }
 
-    // If the node is being deselected and has children, add/remove them accordingly
-    if (!isSelected && nodeData.children && nodeData.children.length > 0) {
-        nodeData.children.forEach((childNode) => {
-            if (!selectedNodes.includes(childNode)) {
-                updatedNodes.push(childNode);
-            }
-        });
-    }
-
+    // Update the selectedNodes state
     setSelectedNodes(updatedNodes);
 };

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -89,3 +89,10 @@ export const updateSelectedNodes = (
     // Update the selectedNodes state
     setSelectedNodes(updatedNodes);
 };
+
+// Helper function to clear the selection status of all selected nodes
+export const clearSelectedNodes = (selectedNodes: TreeNode[]) => {
+    selectedNodes.forEach((node) => {
+        node.selectionStatus = 0;
+    });
+};

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -60,7 +60,7 @@ export const updateSelectedNodes = (
     updatedNodes = isSelected
         ? [...selectedNodes, node]
         : selectedNodes.filter(
-              (selectedNode) => selectedNode.data !== node.data,
+              (selectedNode) => selectedNode.data.path !== node.data.path,
           );
 
     // Recursively toggle selection of the node and its immediate descendants
@@ -73,15 +73,17 @@ export const updateSelectedNodes = (
         const children = parentNode.children || [];
         const totalChildren = children.length;
         const selectedChildren = children.filter((child) => {
-            const updatedNodeIds = updatedNodes.map((node) => node.data.id);
-            return updatedNodeIds.includes(child.data.id);
+            return updatedNodes
+                .map((node) => node.data.path)
+                .includes(child.data.path);
         });
         const selectedChildrenCount = selectedChildren.length;
         if (selectedChildrenCount === 0) {
             // Remove the parent node from the updatedNodes list if it has no children selected
             parentNode.data.selectionStatus = 0;
             updatedNodes = updatedNodes.filter(
-                (selectedNode) => selectedNode.data !== parentNode.data,
+                (selectedNode) =>
+                    selectedNode.data.path !== parentNode.data.path,
             );
         } else if (selectedChildrenCount === totalChildren) {
             // Push the parent node to the updatedNodes list if all children are selected
@@ -109,8 +111,8 @@ export const clearSelectedNodes = (selectedNodes: NodeApi<TreeNode>[]) => {
     selectedNodes.forEach((node) => {
         let currentNode = node;
         while (currentNode.parent) {
-            currentNode = currentNode.parent;
             currentNode.data.selectionStatus = 0;
+            currentNode = currentNode.parent;
         }
     });
 };

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -38,9 +38,7 @@ export const updateSelectedNodes = (
     // Helper function to recursively update the parent nodes with intermediate selection status
     const updateParentNodes = (currentNode: NodeApi<TreeNode>) => {
         const parentNode = currentNode.parent;
-        if (parentNode) {
-            console.log("Current node: ", currentNode.data.path);
-            console.log("Parent node: ", parentNode.data.path);
+        if (parentNode !== null) {
             const children = parentNode.children || [];
             const hasSelectedOrIntermediateChild = children.some(
                 (child) =>
@@ -78,8 +76,14 @@ export const updateSelectedNodes = (
 
         if (selectedChildrenCount === 0) {
             parentNode.data.selectionStatus = 0;
+            // Remove the parent node from the updatedNodes list if it has no children selected
+            updatedNodes = updatedNodes.filter(
+                (selectedNode) => selectedNode !== parentNode.data,
+            );
         } else if (selectedChildrenCount === totalChildren) {
             parentNode.data.selectionStatus = 1;
+            // Add the parent node to the updatedNodes list if all children are selected
+            updatedNodes.push(parentNode.data);
         } else {
             parentNode.data.selectionStatus = 0.5;
         }

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import type { TreeNode } from "@/types/index";
+
+export const updateSelectedNodes = (
+    nodeData: TreeNode,
+    isSelected: boolean,
+    selectedNodes: TreeNode[],
+    setSelectedNodes: (nodes: TreeNode[]) => void,
+) => {
+    let updatedNodes: TreeNode[];
+
+    if (isSelected) {
+        updatedNodes = [...selectedNodes, nodeData];
+    } else {
+        updatedNodes = selectedNodes.filter((node) => node !== nodeData);
+    }
+
+    // If the node is being deselected and has children, add/remove them accordingly
+    if (!isSelected && nodeData.children && nodeData.children.length > 0) {
+        nodeData.children.forEach((childNode) => {
+            if (!selectedNodes.includes(childNode)) {
+                updatedNodes.push(childNode);
+            }
+        });
+    }
+
+    setSelectedNodes(updatedNodes);
+};

--- a/apps/clearance_ui/src/types/index.ts
+++ b/apps/clearance_ui/src/types/index.ts
@@ -13,6 +13,7 @@ export type TreeNode = {
     hasLicenseConclusions: boolean;
     openByDefault?: boolean;
     isExcluded?: boolean;
+    selectionStatus: number; // 1 = selected, 0 = deselected, 0.5 = some children selected
     file?: {
         licenseFindings: LicenseFindings[];
         licenseConclusions: LicenseConclusions[];


### PR DESCRIPTION
This PR brings in a new feature to Clearance UI: filetree selection logic with checkboxes, to be used especially when creating bulk license conclusions and path exclusions.  As this is part of a bigger project, which is still under construction, the new buttons are so far hidden from the Main UI.  With upcoming PRs, they will be taken into use along with redesign of the clearance tools in Main UI.

Note: tree selection sync between license filtering and unfiltered views does not work yet, and there is a separate issue created for that.