### PR TITLE
Do 589 use the generated glob for bulk conclusions and path exclusions

### DIFF
--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
@@ -240,6 +240,7 @@ const BulkConclusionForm = ({ purl, pattern, className, setOpen }: Props) => {
                                                 "!min-h-[40px] text-xs",
                                             )}
                                             placeholder="Glob pattern matching to the files to be concluded..."
+                                            data-testid="glob-pattern"
                                             {...field}
                                         />
                                     </FormControl>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
@@ -58,11 +58,18 @@ type BulkConclusionFormType = z.infer<typeof bulkConclusionFormSchema>;
 type Props = {
     purl: string;
     pattern: string;
+    clearPattern: () => void;
     className?: string;
     setOpen: (open: boolean) => void;
 };
 
-const BulkConclusionForm = ({ purl, pattern, className, setOpen }: Props) => {
+const BulkConclusionForm = ({
+    purl,
+    pattern,
+    clearPattern,
+    className,
+    setOpen,
+}: Props) => {
     const [matchingPaths, setMatchingPaths] = useState<string[]>([]);
     const pathPurl = toPathPurl(purl);
     // Fetch the package file tree data
@@ -117,6 +124,7 @@ const BulkConclusionForm = ({ purl, pattern, className, setOpen }: Props) => {
                         filesPackage: data.affectedFilesInPackageCount,
                         filesAll: data.affectedFilesAcrossAllPackagesCount,
                     };
+                    clearPattern();
                     setOpen(false);
                     toast({
                         title: "Bulk conclusion",

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
@@ -57,7 +57,7 @@ type BulkConclusionFormType = z.infer<typeof bulkConclusionFormSchema>;
 
 type Props = {
     purl: string;
-    pattern?: string;
+    pattern: string;
     className?: string;
     setOpen: (open: boolean) => void;
 };
@@ -75,7 +75,7 @@ const BulkConclusionForm = ({ purl, pattern, className, setOpen }: Props) => {
     const paths =
         fileTreeData?.filetrees.map((filetree) => filetree.path) || [];
     const defaultValues: BulkConclusionFormType = {
-        pattern: pattern || "",
+        pattern: pattern,
         concludedLicenseSPDX: "",
         concludedLicenseList: "",
         comment: "",

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
@@ -57,11 +57,12 @@ type BulkConclusionFormType = z.infer<typeof bulkConclusionFormSchema>;
 
 type Props = {
     purl: string;
+    pattern?: string;
     className?: string;
     setOpen: (open: boolean) => void;
 };
 
-const BulkConclusionForm = ({ purl, className, setOpen }: Props) => {
+const BulkConclusionForm = ({ purl, pattern, className, setOpen }: Props) => {
     const [matchingPaths, setMatchingPaths] = useState<string[]>([]);
     const pathPurl = toPathPurl(purl);
     // Fetch the package file tree data
@@ -74,7 +75,7 @@ const BulkConclusionForm = ({ purl, className, setOpen }: Props) => {
     const paths =
         fileTreeData?.filetrees.map((filetree) => filetree.path) || [];
     const defaultValues: BulkConclusionFormType = {
-        pattern: "",
+        pattern: pattern || "",
         concludedLicenseSPDX: "",
         concludedLicenseList: "",
         comment: "",

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionFormDialog.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionFormDialog.tsx
@@ -10,12 +10,19 @@ import BulkConclusionForm from "@/components/main_ui/inspector/package_inspector
 
 type Props = {
     purl: string;
+    pattern: string;
     id?: number;
     open: boolean;
     setOpen: (open: boolean) => void;
 };
 
-const BulkConclusionFormDialog = ({ purl, id, open, setOpen }: Props) => {
+const BulkConclusionFormDialog = ({
+    purl,
+    pattern,
+    id,
+    open,
+    setOpen,
+}: Props) => {
     return (
         <Dialog open={open} onOpenChange={() => setOpen(!open)}>
             <DialogContent>
@@ -26,7 +33,11 @@ const BulkConclusionFormDialog = ({ purl, id, open, setOpen }: Props) => {
                         setOpen={setOpen}
                     />
                 ) : (
-                    <BulkConclusionForm purl={purl} setOpen={setOpen} />
+                    <BulkConclusionForm
+                        purl={purl}
+                        pattern={pattern}
+                        setOpen={setOpen}
+                    />
                 )}
                 <DialogFooter className="flex justify-end">
                     <Button

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionFormDialog.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionFormDialog.tsx
@@ -11,6 +11,7 @@ import BulkConclusionForm from "@/components/main_ui/inspector/package_inspector
 type Props = {
     purl: string;
     pattern: string;
+    clearPattern: () => void;
     id?: number;
     open: boolean;
     setOpen: (open: boolean) => void;
@@ -19,6 +20,7 @@ type Props = {
 const BulkConclusionFormDialog = ({
     purl,
     pattern,
+    clearPattern,
     id,
     open,
     setOpen,
@@ -36,6 +38,7 @@ const BulkConclusionFormDialog = ({
                     <BulkConclusionForm
                         purl={purl}
                         pattern={pattern}
+                        clearPattern={clearPattern}
                         setOpen={setOpen}
                     />
                 )}

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
@@ -38,7 +38,7 @@ const ClearanceTools = ({
     return (
         <div
             className={cn(
-                "relative mb-2 flex items-center rounded-md border p-1 text-sm",
+                "relative mb-2 flex items-center rounded-md border px-1 pb-1 pt-2 text-sm",
                 className,
             )}
         >
@@ -54,8 +54,8 @@ const ClearanceTools = ({
                                 <Toggle
                                     className={
                                         isSelectionMode
-                                            ? "border border-red-500 p-2"
-                                            : "p-2"
+                                            ? "mr-1 border border-red-500 p-2"
+                                            : "mr-1 p-2"
                                     }
                                     pressed={isSelectionMode}
                                     onPressedChange={() => {
@@ -85,7 +85,7 @@ const ClearanceTools = ({
                             <TooltipTrigger asChild>
                                 <Button
                                     variant="ghost"
-                                    className="p-2"
+                                    className="mr-1 p-2"
                                     onClick={() => onClearSelection()}
                                     data-testid="clear-selection"
                                 >
@@ -103,8 +103,8 @@ const ClearanceTools = ({
                         <div className="group relative">
                             <TooltipTrigger asChild>
                                 <Button
-                                    variant="outline"
-                                    className="p-2 text-xs"
+                                    variant={glob ? "default" : "outline"}
+                                    className="mr-1 p-2 text-xs"
                                     onClick={() => setOpenBCDialog(true)}
                                     data-testid="create-bulk-conclusion"
                                 >
@@ -112,7 +112,9 @@ const ClearanceTools = ({
                                 </Button>
                             </TooltipTrigger>
                             <TooltipContent>
-                                Create a bulk conclusion from your selections
+                                {glob
+                                    ? "Create a bulk conclusion from your selections"
+                                    : "Create a bulk conclusion using your own glob pattern"}
                             </TooltipContent>
                         </div>
                         <BulkConclusionFormDialog
@@ -128,7 +130,7 @@ const ClearanceTools = ({
                         <div className="group relative">
                             <TooltipTrigger asChild>
                                 <Button
-                                    variant="outline"
+                                    variant={glob ? "default" : "outline"}
                                     className="p-2 text-xs"
                                     onClick={() => setOpenPEDialog(true)}
                                     data-testid="create-path-exclusion"
@@ -137,7 +139,9 @@ const ClearanceTools = ({
                                 </Button>
                             </TooltipTrigger>
                             <TooltipContent>
-                                Create a path exclusion from your selections
+                                {glob
+                                    ? "Create a path exclusion from your selections"
+                                    : "Create a path exclusion using your own glob pattern"}
                             </TooltipContent>
                         </div>
                         <ExclusionFormDialog

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
@@ -4,14 +4,6 @@
 
 import React, { useState } from "react";
 import { FiFileMinus, FiFilePlus } from "react-icons/fi";
-import { LuFileStack } from "react-icons/lu";
-import {
-    TbFileOff,
-    TbFilesOff,
-    TbFolderOff,
-    TbFoldersOff,
-} from "react-icons/tb";
-import { TfiPencil } from "react-icons/tfi";
 import { Button } from "@/components/ui/button";
 import { Toggle } from "@/components/ui/toggle";
 import {
@@ -23,37 +15,24 @@ import {
 import BulkConclusionFormDialog from "@/components/main_ui/inspector/package_inspector/BulkConclusionFormDialog";
 import ExclusionFormDialog from "@/components/main_ui/inspector/package_inspector/ExclusionFormDialog";
 import { cn } from "@/lib/utils";
-import type { SelectedNode } from "@/types/index";
 
 type Props = {
-    selectedNode: SelectedNode | undefined;
     purl: string;
     className?: string;
     onSelectionModeChange: (newValue: boolean) => void;
     onClearSelection: () => void;
-};
-
-// Check if the selected node has children directories:
-// if it does, then either this node or this and all subdirs can be excluded
-const hasChildrenDirs = (node: SelectedNode | undefined) => {
-    return node?.children?.some((child: SelectedNode) => !child.isLeaf);
+    glob: string;
 };
 
 const ClearanceTools = ({
-    selectedNode,
     purl,
     className,
     onSelectionModeChange,
     onClearSelection,
+    glob,
 }: Props) => {
-    const [openDirDialog, setOpenDirDialog] = useState<boolean>(false);
-    const [openSubdirsDialog, setOpenSubdirsDialog] = useState<boolean>(false);
-    const [openFileDialog, setOpenFileDialog] = useState<boolean>(false);
-    const [openFileExtDialog, setOpenFileExtDialog] = useState<boolean>(false);
-    const [openFreeTextDialog, setOpenFreeTextDialog] =
-        useState<boolean>(false);
-    const [openBulkConclusionDialog, setOpenBulkConclusionDialog] =
-        useState<boolean>(false);
+    const [openPEDialog, setOpenPEDialog] = useState<boolean>(false);
+    const [openBCDialog, setOpenBCDialog] = useState<boolean>(false);
     const [isSelectionMode, setIsSelectionMode] = useState<boolean>(false);
 
     return (
@@ -68,158 +47,7 @@ const ClearanceTools = ({
             </span>
             <>
                 <TooltipProvider delayDuration={300}>
-                    <Tooltip>
-                        <div className="group relative">
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    disabled={!selectedNode?.isInternal}
-                                    className="p-2"
-                                    onClick={() => setOpenDirDialog(true)}
-                                >
-                                    <TbFolderOff className="text-lg" />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                Exclude this directory
-                            </TooltipContent>
-                        </div>
-                        <ExclusionFormDialog
-                            purl={purl}
-                            mode="Add"
-                            pattern={selectedNode?.data.path + "/*"}
-                            open={openDirDialog}
-                            setOpen={setOpenDirDialog}
-                        />
-                    </Tooltip>
-                    <Tooltip>
-                        <div className="group relative">
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    disabled={!hasChildrenDirs(selectedNode)}
-                                    className="p-2"
-                                    onClick={() => setOpenSubdirsDialog(true)}
-                                >
-                                    <TbFoldersOff
-                                        className="text-lg"
-                                        data-testid="path-exclusion-subdirs"
-                                    />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                Exclude this and all subdirectories
-                            </TooltipContent>
-                        </div>
-                        <ExclusionFormDialog
-                            purl={purl}
-                            mode="Add"
-                            pattern={selectedNode?.data.path + "/**"}
-                            open={openSubdirsDialog}
-                            setOpen={setOpenSubdirsDialog}
-                        />
-                    </Tooltip>
-                    <Tooltip>
-                        <div className="group relative">
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    disabled={!selectedNode?.isLeaf}
-                                    className="p-2"
-                                    onClick={() => setOpenFileDialog(true)}
-                                >
-                                    <TbFileOff className="text-lg" />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Exclude this file</TooltipContent>
-                        </div>
-                        <ExclusionFormDialog
-                            purl={purl}
-                            mode="Add"
-                            pattern={selectedNode?.data.path}
-                            open={openFileDialog}
-                            setOpen={setOpenFileDialog}
-                        />
-                    </Tooltip>
-                    <Tooltip>
-                        <div className="group relative">
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    disabled={!selectedNode?.isLeaf}
-                                    className="p-2"
-                                    onClick={() => setOpenFileExtDialog(true)}
-                                >
-                                    <TbFilesOff
-                                        className="text-lg"
-                                        data-testid="path-exclusion-similar"
-                                    />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                Exclude all files with this extension
-                            </TooltipContent>
-                        </div>
-                        <ExclusionFormDialog
-                            purl={purl}
-                            mode="Add"
-                            pattern={
-                                "**/*." +
-                                selectedNode?.data.path?.split(".").pop()
-                            }
-                            open={openFileExtDialog}
-                            setOpen={setOpenFileExtDialog}
-                        />
-                    </Tooltip>
-                    <Tooltip>
-                        <div className="group relative">
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    className="p-2"
-                                    onClick={() => setOpenFreeTextDialog(true)}
-                                >
-                                    <TfiPencil className="text-lg" />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                Write a freetext path exclusion pattern
-                            </TooltipContent>
-                        </div>
-                        <ExclusionFormDialog
-                            purl={purl}
-                            mode="Add"
-                            pattern={undefined}
-                            open={openFreeTextDialog}
-                            setOpen={setOpenFreeTextDialog}
-                        />
-                    </Tooltip>
-                    <Tooltip>
-                        <div className="group relative">
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="ghost"
-                                    className="p-2"
-                                    onClick={() =>
-                                        setOpenBulkConclusionDialog(true)
-                                    }
-                                >
-                                    <LuFileStack
-                                        className="text-lg"
-                                        data-testid="bulk-conclusion"
-                                    />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                Write a license conclusion for multiple files
-                            </TooltipContent>
-                        </div>
-                        <BulkConclusionFormDialog
-                            purl={purl}
-                            open={openBulkConclusionDialog}
-                            setOpen={setOpenBulkConclusionDialog}
-                        />
-                    </Tooltip>
+                    {/* Selection mode toggle */}
                     <Tooltip>
                         <div className="group relative">
                             <TooltipTrigger asChild>
@@ -234,6 +62,7 @@ const ClearanceTools = ({
                                         setIsSelectionMode(!isSelectionMode);
                                         onSelectionModeChange(!isSelectionMode);
                                     }}
+                                    data-testid="selection-mode-toggle"
                                 >
                                     {isSelectionMode ? (
                                         <FiFilePlus className="text-lg text-red-500" />
@@ -249,6 +78,8 @@ const ClearanceTools = ({
                             </TooltipContent>
                         </div>
                     </Tooltip>
+
+                    {/* Clear selection */}
                     <Tooltip>
                         <div className="group relative">
                             <TooltipTrigger asChild>
@@ -256,6 +87,7 @@ const ClearanceTools = ({
                                     variant="ghost"
                                     className="p-2"
                                     onClick={() => onClearSelection()}
+                                    data-testid="clear-selection"
                                 >
                                     <FiFileMinus className="text-lg" />
                                 </Button>
@@ -264,6 +96,57 @@ const ClearanceTools = ({
                                 Clear all selections from the tree
                             </TooltipContent>
                         </div>
+                    </Tooltip>
+
+                    {/* Create bulk conclusion from selection */}
+                    <Tooltip>
+                        <div className="group relative">
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    className="p-2 text-xs"
+                                    onClick={() => setOpenBCDialog(true)}
+                                    data-testid="create-bulk-conclusion"
+                                >
+                                    BulkC
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                Create a bulk conclusion from your selections
+                            </TooltipContent>
+                        </div>
+                        <BulkConclusionFormDialog
+                            purl={purl}
+                            pattern={glob}
+                            open={openBCDialog}
+                            setOpen={setOpenBCDialog}
+                        />
+                    </Tooltip>
+
+                    {/* Create path exclusion from selection */}
+                    <Tooltip>
+                        <div className="group relative">
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    className="p-2 text-xs"
+                                    onClick={() => setOpenPEDialog(true)}
+                                    data-testid="create-path-exclusion"
+                                >
+                                    PathE
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                Create a path exclusion from your selections
+                            </TooltipContent>
+                        </div>
+                        <ExclusionFormDialog
+                            purl={purl}
+                            mode="Add"
+                            pattern={glob}
+                            open={openPEDialog}
+                            setOpen={setOpenPEDialog}
+                        />
                     </Tooltip>
                 </TooltipProvider>
             </>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ClearanceTools.tsx
@@ -120,6 +120,7 @@ const ClearanceTools = ({
                         <BulkConclusionFormDialog
                             purl={purl}
                             pattern={glob}
+                            clearPattern={() => onClearSelection()}
                             open={openBCDialog}
                             setOpen={setOpenBCDialog}
                         />
@@ -148,6 +149,7 @@ const ClearanceTools = ({
                             purl={purl}
                             mode="Add"
                             pattern={glob}
+                            clearPattern={() => onClearSelection()}
                             open={openPEDialog}
                             setOpen={setOpenPEDialog}
                         />

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
@@ -34,9 +34,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
+import { patternGlobSchema } from "@/schemes/pattern_schema";
 
 const exclusionFormSchema = z.object({
-    pattern: z.string().min(1, "Pattern cannot be empty"),
+    pattern: patternGlobSchema,
     reason: z.string().min(1, "Please select a valid reason from this list"),
     comment: z.string().optional(),
 });
@@ -47,7 +48,7 @@ type Props = {
     purl: string;
     mode: "Edit" | "Add";
     id?: number;
-    pattern?: string;
+    pattern: string;
     reason?: string;
     comment?: string;
     setOpen: (open: boolean) => void;
@@ -63,7 +64,7 @@ const ExclusionForm = ({
     setOpen,
 }: Props) => {
     const defaultValues: ExclusionFormType = {
-        pattern: pattern || "",
+        pattern: pattern,
         reason: reason || "",
         comment: comment || "",
     };
@@ -223,9 +224,8 @@ const ExclusionForm = ({
                                     </FormControl>
                                     <SelectContent className="max-h-[40vh] overflow-y-auto">
                                         {validReasons.map((reason) => (
-                                            <SelectGroup>
+                                            <SelectGroup key={reason.name}>
                                                 <SelectItem
-                                                    key={reason.name}
                                                     value={reason.name}
                                                     onSelect={() =>
                                                         field.onChange(
@@ -236,10 +236,7 @@ const ExclusionForm = ({
                                                 >
                                                     {reason.name}
                                                 </SelectItem>
-                                                <SelectLabel
-                                                    key={reason.description}
-                                                    className="text-muted-foreground mb-1 ml-5 py-0.5 text-xs font-normal italic"
-                                                >
+                                                <SelectLabel className="text-muted-foreground mb-1 ml-5 py-0.5 text-xs font-normal italic">
                                                     {reason.description}
                                                 </SelectLabel>
                                             </SelectGroup>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
@@ -49,6 +49,7 @@ type Props = {
     mode: "Edit" | "Add";
     id?: number;
     pattern: string;
+    clearPattern: () => void;
     reason?: string;
     comment?: string;
     setOpen: (open: boolean) => void;
@@ -59,6 +60,7 @@ const ExclusionForm = ({
     mode,
     id,
     pattern,
+    clearPattern,
     reason,
     comment,
     setOpen,
@@ -91,6 +93,7 @@ const ExclusionForm = ({
             },
             {
                 onSuccess: () => {
+                    clearPattern();
                     setOpen(false);
                     toast({
                         title: "Path exclusion",

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
@@ -203,6 +203,7 @@ const ExclusionForm = ({
                                     <Input
                                         className="!min-h-[40px] text-xs"
                                         placeholder="Glob pattern matching to the path to be excluded..."
+                                        data-testid="glob-pattern"
                                         {...field}
                                     />
                                 </FormControl>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionFormDialog.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionFormDialog.tsx
@@ -11,7 +11,8 @@ type Props = {
     purl: string;
     mode: "Edit" | "Add";
     id?: number;
-    pattern?: string;
+    pattern: string;
+    clearPattern: () => void;
     reason?: string;
     comment?: string;
     open: boolean;
@@ -23,6 +24,7 @@ const ExclusionFormDialog = ({
     mode,
     id,
     pattern,
+    clearPattern,
     reason,
     comment,
     open,
@@ -36,6 +38,7 @@ const ExclusionFormDialog = ({
                     mode={mode}
                     id={id}
                     pattern={pattern}
+                    clearPattern={clearPattern}
                     reason={reason}
                     comment={comment}
                     setOpen={setOpen}

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -31,7 +31,6 @@ import { toPathPurl } from "@/helpers/pathParamHelpers";
 import { stringToColour } from "@/helpers/stringToColour";
 import {
     clearSelectedNodes,
-    createGlob,
     updateSelectedNodes,
 } from "@/helpers/treeSelectionUtils";
 import { updateHasLicenseFindings } from "@/helpers/updateHasLicenseFindings";
@@ -56,7 +55,7 @@ const PackageInspector = ({ purl, path }: Props) => {
     const [treeHeight, setTreeHeight] = useState(0);
     const [treeData, setTreeData] = useState<TreeNode[]>([]);
     const [originalTreeData, setOriginalTreeData] = useState<TreeNode[]>([]);
-    const [selectedNode, setSelectedNode] = useState<SelectedNode>();
+    const [, setSelectedNode] = useState<SelectedNode>();
     const [openedNodeId, setOpenedNodeId] = useState<string>();
     const [isSelectionMode, setIsSelectionMode] = useState(false);
     const [selectedNodes, setSelectedNodes] = useState<NodeApi<TreeNode>[]>([]);

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -60,6 +60,7 @@ const PackageInspector = ({ purl, path }: Props) => {
     const [openedNodeId, setOpenedNodeId] = useState<string>();
     const [isSelectionMode, setIsSelectionMode] = useState(false);
     const [selectedNodes, setSelectedNodes] = useState<NodeApi<TreeNode>[]>([]);
+    const [glob, setGlob] = useState<string>("");
     const treeRef = useRef<HTMLDivElement>(null);
 
     const router = useRouter();
@@ -114,7 +115,13 @@ const PackageInspector = ({ purl, path }: Props) => {
         node: NodeApi<TreeNode>,
         isSelected: boolean,
     ): void => {
-        updateSelectedNodes(node, isSelected, selectedNodes, setSelectedNodes);
+        updateSelectedNodes(
+            node,
+            isSelected,
+            selectedNodes,
+            setSelectedNodes,
+            setGlob,
+        );
     };
 
     useEffect(() => {
@@ -190,16 +197,8 @@ const PackageInspector = ({ purl, path }: Props) => {
     }, [path, treeData, tree]);
 
     useEffect(() => {
-        if (/*selectedNodes.length > 0*/ true) {
-            /*
-            console.log(
-                "selected paths:",
-                selectedNodes.map((node) => node.data.path),
-            );
-            */
-            createGlob(selectedNodes);
-        }
-    }, [selectedNodes]);
+        console.log("glob:", glob);
+    }, [glob]);
 
     return (
         <div className="flex h-full flex-col">
@@ -235,7 +234,7 @@ const PackageInspector = ({ purl, path }: Props) => {
                         setIsSelectionMode(mode);
                     }}
                     onClearSelection={() => {
-                        clearSelectedNodes(selectedNodes);
+                        clearSelectedNodes(selectedNodes, setGlob);
                         setSelectedNodes([]);
                     }}
                 />

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -196,10 +196,6 @@ const PackageInspector = ({ purl, path }: Props) => {
         }
     }, [path, treeData, tree]);
 
-    useEffect(() => {
-        console.log("glob:", glob);
-    }, [glob]);
-
     return (
         <div className="flex h-full flex-col">
             <div className="mb-3 flex items-center text-sm">

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -227,7 +227,6 @@ const PackageInspector = ({ purl, path }: Props) => {
             </div>
             <div className="flex items-center justify-between">
                 <ClearanceTools
-                    selectedNode={selectedNode}
                     purl={purl}
                     className="mr-2 flex-1"
                     onSelectionModeChange={(mode) => {
@@ -237,6 +236,7 @@ const PackageInspector = ({ purl, path }: Props) => {
                         clearSelectedNodes(selectedNodes, setGlob);
                         setSelectedNodes([]);
                     }}
+                    glob={glob}
                 />
                 <TooltipProvider delayDuration={300}>
                     <Tooltip>

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -264,7 +264,7 @@ function hasFilesAndDirs(node: NodeApi<TreeNode>): boolean {
 }
 
 // Helper function to check if path1 is a subset of path2
-function isPathSubset(path1: string, path2: string): boolean {
+export function isPathSubset(path1: string, path2: string): boolean {
     // Remove "/**" from the paths before splitting them into parts
     const parts1 = path1.replace("/**", "").split("/");
     const parts2 = path2.replace("/**", "").split("/");
@@ -273,7 +273,7 @@ function isPathSubset(path1: string, path2: string): boolean {
 
 // Helper function to remove lower-level paths from a string[] of paths
 // Example: if the input is ["a/b/**", "a/**"], the output will be ["a/**"]
-function removeInnerSubstitutions(paths: string[]): string[] {
+export function removeInnerSubstitutions(paths: string[]): string[] {
     return paths.filter(
         (path, _, self) =>
             !self.some(
@@ -285,7 +285,7 @@ function removeInnerSubstitutions(paths: string[]): string[] {
 
 // Helper function that takes an array of file paths and groups them
 // into a single glob pattern
-function generateGlobPattern(paths: string[]): string {
+export function generateGlobPattern(paths: string[]): string {
     const patterns: string[] = [];
 
     // Group paths by directory

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -78,7 +78,7 @@ export const updateSelectedNodes = (
     // Recursively toggle selection of the node and its immediate descendants
     toggleSelectionRecursive(node, isSelected);
 
-    // Check if all children of the parent node are selected or deselected,
+    // Check how many of the parent node are selected or deselected,
     // and update the parent's selection status accordingly
     const parentNode = node.parent;
     if (parentNode) {
@@ -90,6 +90,7 @@ export const updateSelectedNodes = (
                 .includes(child.data.path);
         });
         const selectedChildrenCount = selectedChildren.length;
+        console.log("selectedChildrenCount: ", selectedChildrenCount);
         if (selectedChildrenCount === 0) {
             // Remove the parent node from the updatedNodes list if it has no children selected
             parentNode.data.selectionStatus = 0;
@@ -130,165 +131,6 @@ export const clearSelectedNodes = (selectedNodes: NodeApi<TreeNode>[]) => {
 
 // Function to create a simplified glob pattern from the selected nodes
 export const createGlob = (selectedNodes: NodeApi<TreeNode>[]) => {
-    // Helper function that takes an array of file paths and groups them
-    // into a single glob pattern
-    function generateGlobPattern(paths: string[]): string {
-        const patterns: string[] = [];
-
-        // Group paths by directory
-        const groupedPaths: { [key: string]: string[] } = {};
-        paths.forEach((path) => {
-            const directory =
-                path.lastIndexOf("/") === -1
-                    ? ""
-                    : path.substring(0, path.lastIndexOf("/") + 1);
-            const filename = path.substring(directory.length);
-            if (!groupedPaths[directory]) {
-                groupedPaths[directory] = [];
-            }
-            groupedPaths[directory].push(filename);
-        });
-
-        // Construct glob pattern for each directory
-        for (const directory in groupedPaths) {
-            const files = groupedPaths[directory];
-            let pattern;
-            // Handle root directory separately
-            if (directory === "") {
-                pattern =
-                    files.length === 1 ? files[0] : `{${files.join(",")}}`;
-            } else {
-                // Construct pattern based on the number of selected files
-                pattern =
-                    files.length === 1
-                        ? `${directory}${files[0]}`
-                        : `${directory}{${files.join(",")}}`;
-            }
-            patterns.push(pattern);
-        }
-
-        // Join the patterns with ',' to create a single glob pattern
-        let globPattern = patterns.join(",");
-
-        // Surround the pattern with curly braces if it contains multiple patterns
-        if (patterns.length > 1) {
-            globPattern = `{${globPattern}}`;
-        }
-
-        return globPattern;
-    }
-
-    // Helper function that takes in an array of nodes and a glob pattern,
-    // and returns an array of nodes that don't match the glob pattern.
-    function filterNodesByGlob(
-        nodes: NodeApi<TreeNode>[],
-        globPattern: string,
-    ): NodeApi<TreeNode>[] {
-        return nodes.filter((node) => {
-            return !minimatch(node.data.path ?? "", globPattern, { dot: true });
-        });
-    }
-
-    // Helper function that takes an internal node (directory) and returns
-    // all its descendants that have a selectionStatus of 1 (selected)
-    function getDescendants(node: NodeApi<TreeNode>): NodeApi<TreeNode>[] {
-        const descendants: NodeApi<TreeNode>[] = [];
-        if (node.children) {
-            node.children.forEach((child) => {
-                if (child.data.selectionStatus === 1) {
-                    descendants.push(child);
-                } else {
-                    descendants.push(...getDescendants(child));
-                }
-            });
-        }
-        return descendants;
-    }
-
-    // Helper function that takes an internal node (directory) and if its selectionStatus
-    // is 1 (selected), removes it and all its descendants from the selectedNodes list
-    function removeNodeAndDescendants(
-        node: NodeApi<TreeNode>,
-        nodes: NodeApi<TreeNode>[],
-    ) {
-        if (node.data.selectionStatus === 1) {
-            nodes = nodes.filter((n) => {
-                return n !== node && !getDescendants(node).includes(n);
-            });
-        }
-        return nodes;
-    }
-
-    // Helper function to remove lower-level paths from a string[] of paths
-    // Example: if the input is ["a/b/**", "a/**"], the output will be ["a/**"]
-    function removeInnerSubstitutions(paths: string[]): string[] {
-        return paths.filter(
-            (path, _, self) =>
-                !self.some(
-                    (otherPath) =>
-                        otherPath !== path && isPathSubset(otherPath, path),
-                ),
-        );
-    }
-
-    // Helper function to check if path1 is a subset of path2
-    function isPathSubset(path1: string, path2: string): boolean {
-        // Remove "/**" from the paths before splitting them into parts
-        const parts1 = path1.replace("/**", "").split("/");
-        const parts2 = path2.replace("/**", "").split("/");
-        return parts1.every((part, index) => part === parts2[index]);
-    }
-
-    // Helper function which takes in an array of nodes
-    // and groups the nodes by their parent directory
-    function groupNodesByDirectory(nodes: NodeApi<TreeNode>[]): {
-        [dir: string]: NodeApi<TreeNode>[];
-    } {
-        const groupedNodes: { [dir: string]: NodeApi<TreeNode>[] } = {};
-        nodes.forEach((node) => {
-            const directory =
-                node.data.path?.lastIndexOf("/") === -1
-                    ? ""
-                    : node.data.path?.substring(
-                          0,
-                          node.data.path.lastIndexOf("/") + 1,
-                      );
-            if (directory && !groupedNodes[directory]) {
-                groupedNodes[directory] = [];
-            }
-            if (directory) groupedNodes[directory].push(node);
-        });
-        return groupedNodes;
-    }
-
-    // Helper function which returns true, if the directory the node is in
-    // contains both files (isLeaf) and subdirectories (isInternal).
-    function hasFilesAndDirs(node: NodeApi<TreeNode>): boolean {
-        const parent = node.parent;
-        const children = parent?.children;
-        const nFiles = children?.filter((node) => node.isLeaf).length;
-        const nDirs = children?.filter((node) => node.isInternal).length;
-        if (nFiles && nFiles > 0 && nDirs && nDirs > 0) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    // Helper function that takes in a node and returns all its
-    // siblings, ie. nodes that share the same parent and are leafs (isLeaf)
-    function getSiblings(node: NodeApi<TreeNode>): NodeApi<TreeNode>[] {
-        const parent = node.parent;
-        if (parent) {
-            return parent.children?.filter((child) => child.isLeaf) || [];
-        }
-        return [];
-    }
-
-    /******************************************************
-     ** Main part
-     ******************************************************/
-
     let remainingNodes = selectedNodes;
     let pattern: string[] = [];
 
@@ -325,7 +167,7 @@ export const createGlob = (selectedNodes: NodeApi<TreeNode>[]) => {
         const firstNode = groupedNodes[dir][0];
         const parent = firstNode.parent;
         if (hasFilesAndDirs(firstNode)) {
-            const siblings = getSiblings(firstNode);
+            const siblings = getFileSiblings(firstNode);
             if (groupedNodes[dir].length === siblings.length) {
                 // Push to glob only if the pattern is not already included
                 if (parent && !pattern.includes(parent.data.path + "/*")) {
@@ -346,3 +188,176 @@ export const createGlob = (selectedNodes: NodeApi<TreeNode>[]) => {
     console.log("final glob pattern: ", globPattern);
     return globPattern;
 };
+
+/**
+ * Helper functions
+ */
+
+// Helper function that returns the number of selected children of a node
+// Returned value is a string: "all", "some" or "none"
+export const getSelectedChildrenStatus = (node: NodeApi<TreeNode>) => {
+    const selectedChildren = node.children?.filter(
+        (child) => child.data.selectionStatus === 1,
+    );
+    if (selectedChildren?.length === 0) {
+        return "none";
+    } else if (selectedChildren?.length === node.children?.length) {
+        return "all";
+    } else {
+        return "some";
+    }
+};
+
+// Helper function that takes in an array of nodes and a glob pattern,
+// and returns an array of nodes that don't match the glob pattern.
+function filterNodesByGlob(
+    nodes: NodeApi<TreeNode>[],
+    globPattern: string,
+): NodeApi<TreeNode>[] {
+    return nodes.filter((node) => {
+        return !minimatch(node.data.path ?? "", globPattern, { dot: true });
+    });
+}
+
+// Helper function that takes in a node and returns all its
+// siblings, ie. nodes that share the same parent and are leafs (isLeaf)
+function getFileSiblings(node: NodeApi<TreeNode>): NodeApi<TreeNode>[] {
+    const parent = node.parent;
+    if (parent) {
+        return parent.children?.filter((child) => child.isLeaf) || [];
+    }
+    return [];
+}
+
+// Helper function which takes in an array of nodes
+// and groups the nodes by their parent directory
+function groupNodesByDirectory(nodes: NodeApi<TreeNode>[]): {
+    [dir: string]: NodeApi<TreeNode>[];
+} {
+    const groupedNodes: { [dir: string]: NodeApi<TreeNode>[] } = {};
+    nodes.forEach((node) => {
+        const directory =
+            node.data.path?.lastIndexOf("/") === -1
+                ? ""
+                : node.data.path?.substring(
+                      0,
+                      node.data.path.lastIndexOf("/") + 1,
+                  );
+        if (directory && !groupedNodes[directory]) {
+            groupedNodes[directory] = [];
+        }
+        if (directory) groupedNodes[directory].push(node);
+    });
+    return groupedNodes;
+}
+
+// Helper function which returns true, if the directory the node is in
+// contains both files (isLeaf) and subdirectories (isInternal).
+function hasFilesAndDirs(node: NodeApi<TreeNode>): boolean {
+    const parent = node.parent;
+    const children = parent?.children;
+    const nFiles = children?.filter((node) => node.isLeaf).length;
+    const nDirs = children?.filter((node) => node.isInternal).length;
+    if (nFiles && nFiles > 0 && nDirs && nDirs > 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// Helper function to check if path1 is a subset of path2
+function isPathSubset(path1: string, path2: string): boolean {
+    // Remove "/**" from the paths before splitting them into parts
+    const parts1 = path1.replace("/**", "").split("/");
+    const parts2 = path2.replace("/**", "").split("/");
+    return parts1.every((part, index) => part === parts2[index]);
+}
+
+// Helper function to remove lower-level paths from a string[] of paths
+// Example: if the input is ["a/b/**", "a/**"], the output will be ["a/**"]
+function removeInnerSubstitutions(paths: string[]): string[] {
+    return paths.filter(
+        (path, _, self) =>
+            !self.some(
+                (otherPath) =>
+                    otherPath !== path && isPathSubset(otherPath, path),
+            ),
+    );
+}
+
+// Helper function that takes an array of file paths and groups them
+// into a single glob pattern
+function generateGlobPattern(paths: string[]): string {
+    const patterns: string[] = [];
+
+    // Group paths by directory
+    const groupedPaths: { [key: string]: string[] } = {};
+    paths.forEach((path) => {
+        const directory =
+            path.lastIndexOf("/") === -1
+                ? ""
+                : path.substring(0, path.lastIndexOf("/") + 1);
+        const filename = path.substring(directory.length);
+        if (!groupedPaths[directory]) {
+            groupedPaths[directory] = [];
+        }
+        groupedPaths[directory].push(filename);
+    });
+
+    // Construct glob pattern for each directory
+    for (const directory in groupedPaths) {
+        const files = groupedPaths[directory];
+        let pattern;
+        // Handle root directory separately
+        if (directory === "") {
+            pattern = files.length === 1 ? files[0] : `{${files.join(",")}}`;
+        } else {
+            // Construct pattern based on the number of selected files
+            pattern =
+                files.length === 1
+                    ? `${directory}${files[0]}`
+                    : `${directory}{${files.join(",")}}`;
+        }
+        patterns.push(pattern);
+    }
+
+    // Join the patterns with ',' to create a single glob pattern
+    let globPattern = patterns.join(",");
+
+    // Surround the pattern with curly braces if it contains multiple patterns
+    if (patterns.length > 1) {
+        globPattern = `{${globPattern}}`;
+    }
+
+    return globPattern;
+}
+
+// Helper function that takes an internal node (directory) and returns
+// all its descendants that have a selectionStatus of 1 (selected)
+function getDescendants(node: NodeApi<TreeNode>): NodeApi<TreeNode>[] {
+    const descendants: NodeApi<TreeNode>[] = [];
+    if (node.children) {
+        node.children.forEach((child) => {
+            if (child.data.selectionStatus === 1) {
+                descendants.push(child);
+            } else {
+                descendants.push(...getDescendants(child));
+            }
+        });
+    }
+    return descendants;
+}
+
+// Helper function that takes an internal node (directory) and if its selectionStatus
+// is 1 (selected), removes it and all its descendants from the selectedNodes list
+function removeNodeAndDescendants(
+    node: NodeApi<TreeNode>,
+    nodes: NodeApi<TreeNode>[],
+) {
+    if (node.data.selectionStatus === 1) {
+        nodes = nodes.filter((n) => {
+            return n !== node && !getDescendants(node).includes(n);
+        });
+    }
+    return nodes;
+}

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -5,6 +5,7 @@
 import { sortBy } from "lodash";
 import { minimatch } from "minimatch";
 import { NodeApi } from "react-arborist";
+import { get } from "react-hook-form";
 import type { TreeNode } from "@/types/index";
 
 // Function to update the selection status of the selected nodes
@@ -38,7 +39,7 @@ export const updateSelectedNodes = (
         currentNode.data.selectionStatus = select ? 1 : 0;
     };
 
-    // Helper function to recursively update the parent nodes with intermediate selection status
+    // Helper function to recursively update the parent nodes's status up the tree
     const updateParentNodes = (currentNode: NodeApi<TreeNode>) => {
         const parentNode = currentNode.parent;
         if (parentNode !== null) {
@@ -78,27 +79,19 @@ export const updateSelectedNodes = (
     // Recursively toggle selection of the node and its immediate descendants
     toggleSelectionRecursive(node, isSelected);
 
-    // Check how many of the parent node are selected or deselected,
+    // Check how many children of the parent node are selected or deselected,
     // and update the parent's selection status accordingly
     const parentNode = node.parent;
     if (parentNode) {
-        const children = parentNode.children || [];
-        const totalChildren = children.length;
-        const selectedChildren = children.filter((child) => {
-            return updatedNodes
-                .map((node) => node.data.path)
-                .includes(child.data.path);
-        });
-        const selectedChildrenCount = selectedChildren.length;
-        console.log("selectedChildrenCount: ", selectedChildrenCount);
-        if (selectedChildrenCount === 0) {
+        const selectedChildren = getSelectedChildrenStatus(parentNode);
+        if (selectedChildren === "none") {
             // Remove the parent node from the updatedNodes list if it has no children selected
             parentNode.data.selectionStatus = 0;
             updatedNodes = updatedNodes.filter(
                 (selectedNode) =>
                     selectedNode.data.path !== parentNode.data.path,
             );
-        } else if (selectedChildrenCount === totalChildren) {
+        } else if (selectedChildren === "all") {
             // Push the parent node to the updatedNodes list if all children are selected
             parentNode.data.selectionStatus = 1;
             updatedNodes.push(parentNode);

--- a/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
+++ b/apps/clearance_ui/src/helpers/treeSelectionUtils.ts
@@ -5,7 +5,6 @@
 import { sortBy } from "lodash";
 import { minimatch } from "minimatch";
 import { NodeApi } from "react-arborist";
-import { get } from "react-hook-form";
 import type { TreeNode } from "@/types/index";
 
 // Function to update the selection status of the selected nodes
@@ -14,6 +13,7 @@ export const updateSelectedNodes = (
     isSelected: boolean,
     selectedNodes: NodeApi<TreeNode>[],
     setSelectedNodes: (nodes: NodeApi<TreeNode>[]) => void,
+    setGlob: (glob: string) => void,
 ) => {
     // Helper function to recursively select or deselect nodes
     const toggleSelectionRecursive = (
@@ -103,10 +103,14 @@ export const updateSelectedNodes = (
 
     // Update the selectedNodes state
     setSelectedNodes(updatedNodes);
+    setGlob(createGlob(updatedNodes));
 };
 
 // Function to clear the selection status of all selected nodes
-export const clearSelectedNodes = (selectedNodes: NodeApi<TreeNode>[]) => {
+export const clearSelectedNodes = (
+    selectedNodes: NodeApi<TreeNode>[],
+    setGlob: (glob: string) => void,
+) => {
     // Clear the selected nodes
     selectedNodes.forEach((node) => {
         node.data.selectionStatus = 0;
@@ -120,6 +124,8 @@ export const clearSelectedNodes = (selectedNodes: NodeApi<TreeNode>[]) => {
             currentNode = currentNode.parent;
         }
     });
+    // Clear the glob
+    setGlob("");
 };
 
 // Function to create a simplified glob pattern from the selected nodes
@@ -178,7 +184,6 @@ export const createGlob = (selectedNodes: NodeApi<TreeNode>[]) => {
 
     remainingNodes.map((node) => pattern.push(node.data.path ?? ""));
     const globPattern = generateGlobPattern(pattern);
-    console.log("final glob pattern: ", globPattern);
     return globPattern;
 };
 

--- a/apps/clearance_ui/tests/e2e/logged-as-test-user/bulk-conclusion.spec.ts
+++ b/apps/clearance_ui/tests/e2e/logged-as-test-user/bulk-conclusion.spec.ts
@@ -290,5 +290,6 @@ test("create freetext bulk conclusion, edit, and delete from clearance toolbar",
         "Bulk license conclusion deleted successfully,",
     );
     await toastDeleted.waitFor({ state: "hidden" });
+    await page.getByRole("link", { name: "Inspect" }).click();
     console.log("bulk license conclusion deleted from clearance toolbar");
 });

--- a/apps/clearance_ui/tests/e2e/logged-as-test-user/bulk-conclusion.spec.ts
+++ b/apps/clearance_ui/tests/e2e/logged-as-test-user/bulk-conclusion.spec.ts
@@ -13,17 +13,21 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("create bulk conclusion, delete from Main UI", async ({ page }) => {
-    const pattern = "**/*.ts";
+    const pattern = "apps/scanner_agent/*";
     const license = "AGPL-1.0-only";
     const comment = "Test create bulk conclusion, delete from Main UI";
 
     // Create a bulk license conclusion
     await page.getByText("apps").click();
-    await page.getByText("api").click();
-    await page.getByRole("link", { name: "tsup.config.ts" }).click();
-    await page.getByTestId("bulk-conclusion").click();
-    await page.getByPlaceholder("Glob pattern matching to the").click();
-    await page.getByPlaceholder("Glob pattern matching to the").fill(pattern);
+    await page.getByText("scanner_agent").click();
+    await page.getByTestId("selection-mode-toggle").click();
+    await page.locator('[id="\\32 68"]').click();
+    await page.locator('[id="\\32 69"]').click();
+    await page.locator('[id="\\32 80"]').click();
+    await page.locator('[id="\\32 81"]').click();
+    await page.locator('[id="\\32 82"]').click();
+    await page.getByTestId("create-bulk-conclusion").click();
+    await expect(page.getByTestId("glob-pattern")).toHaveValue(pattern);
     await page.getByRole("combobox").getByText("Select license...").click();
     await page.getByText(license, { exact: true }).click();
     await page.getByPlaceholder("Comment on your bulk").click();
@@ -42,6 +46,9 @@ test("create bulk conclusion, delete from Main UI", async ({ page }) => {
     console.log("bulk license conclusion created");
 
     // Delete the same bulk license conclusion
+    await page.getByText("apps").click();
+    await page.getByText("scanner_agent").click();
+    await page.getByText(".eslintrc.js").click();
     await page
         .getByRole("button", { name: "license conclusion details" })
         .first()
@@ -65,15 +72,18 @@ test("create bulk conclusion, delete from Main UI", async ({ page }) => {
 test("create bulk conclusion, delete from Clearance Library", async ({
     page,
 }) => {
-    const pattern = "**/*.json";
+    const pattern = "apps/api/**";
     const license = "CC-BY-1.0";
     const comment =
         "Test create bulk conclusion, delete from Clearance Library";
 
     // Create a bulk conclusion
-    await page.getByTestId("bulk-conclusion").click();
-    await page.getByPlaceholder("Glob pattern matching to the").click();
-    await page.getByPlaceholder("Glob pattern matching to the").fill(pattern);
+    await page.getByText("apps").click();
+    await page.getByText("api").click();
+    await page.getByTestId("selection-mode-toggle").click();
+    await page.locator('[id="\\32 "]').click();
+    await page.getByTestId("create-bulk-conclusion").click();
+    await expect(page.getByTestId("glob-pattern")).toHaveValue(pattern);
     await page.getByRole("combobox").getByText("Select license...").click();
     await page.getByText(license, { exact: true }).click();
     await page.getByPlaceholder("Comment on your bulk").click();
@@ -114,7 +124,7 @@ test("create bulk conclusion, delete from Clearance Library", async ({
 test("create bulk conclusion, edit, and delete from Main UI", async ({
     page,
 }) => {
-    const pattern = "**/*.ts";
+    const pattern = "{apps/api/src/cron_jobs/**,apps/api/src/helpers/**}";
     const license = "BSD-1-Clause";
     const comment =
         "Test create bulk conclusion, edit, and delete from Main UI";
@@ -125,10 +135,12 @@ test("create bulk conclusion, edit, and delete from Main UI", async ({
     // Create a bulk conclusion
     await page.getByText("apps").click();
     await page.getByText("api").click();
-    await page.getByRole("link", { name: "tsup.config.ts" }).click();
-    await page.getByTestId("bulk-conclusion").click();
-    await page.getByPlaceholder("Glob pattern matching to the").click();
-    await page.getByPlaceholder("Glob pattern matching to the").fill(pattern);
+    await page.getByText("src").click();
+    await page.getByTestId("selection-mode-toggle").click();
+    await page.locator('[id="\\36 "]').click();
+    await page.locator('[id="\\31 0"]').click();
+    await page.getByTestId("create-bulk-conclusion").click();
+    await expect(page.getByTestId("glob-pattern")).toHaveValue(pattern);
     await page.getByRole("combobox").getByText("Select license...").click();
     await page.getByText(license, { exact: true }).click();
     await page.getByPlaceholder("Comment on your bulk").click();
@@ -147,6 +159,11 @@ test("create bulk conclusion, edit, and delete from Main UI", async ({
     console.log("bulk license conclusion created");
 
     // Edit the bulk conclusion
+    await page.getByText("apps").click();
+    await page.getByText("api").click();
+    await page.getByText("src").click();
+    await page.getByText("cron_jobs").click();
+    await page.getByText("index.ts").click();
     await page
         .getByRole("button", { name: "license conclusion details" })
         .first()
@@ -191,7 +208,7 @@ test("create bulk conclusion, edit, and delete from Main UI", async ({
     console.log("bulk license conclusion deleted from Main UI");
 });
 
-test("create bulk conclusion, edit, and delete from clearance toolbar", async ({
+test("create freetext bulk conclusion, edit, and delete from clearance toolbar", async ({
     page,
 }) => {
     const pattern = "**/*.ts";
@@ -206,7 +223,7 @@ test("create bulk conclusion, edit, and delete from clearance toolbar", async ({
     await page.getByText("apps").click();
     await page.getByText("api").click();
     await page.getByRole("link", { name: "tsup.config.ts" }).click();
-    await page.getByTestId("bulk-conclusion").click();
+    await page.getByTestId("create-bulk-conclusion").click();
     await page.getByPlaceholder("Glob pattern matching to the").click();
     await page.getByPlaceholder("Glob pattern matching to the").fill(pattern);
     await page.getByRole("combobox").getByText("Select license...").click();

--- a/apps/clearance_ui/tests/e2e/logged-as-test-user/path-exclusion.spec.ts
+++ b/apps/clearance_ui/tests/e2e/logged-as-test-user/path-exclusion.spec.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ page }) => {
 test("create path exclusion, edit, and delete from Main UI", async ({
     page,
 }) => {
-    const pattern = "apps/api/src/**";
+    const pattern = "apps/api/tests/**";
     const reason = "OTHER";
     const comment =
         "Test create license conclusion, edit it, and finally delete from Main UI";
@@ -26,9 +26,11 @@ test("create path exclusion, edit, and delete from Main UI", async ({
     // Create a path exclusion
     await page.getByText("apps").click();
     await page.getByText("api").click();
-    await page.getByText("src").click();
-    await page.getByTestId("path-exclusion-subdirs").click();
-    await expect(page.getByLabel("Pattern")).toHaveValue(pattern);
+    await page.getByText("tests").click();
+    await page.getByTestId("selection-mode-toggle").click();
+    await page.locator('[id="\\33 6"]').click();
+    await page.getByTestId("create-path-exclusion").click();
+    await expect(page.getByTestId("glob-pattern")).toHaveValue(pattern);
     await page.getByLabel("Reason").click();
     await page.getByLabel(reason, { exact: true }).click();
     await page.getByPlaceholder("Comment...").click();
@@ -97,14 +99,21 @@ test("create path exclusion, edit, and delete from Main UI", async ({
 test("create path exclusion, delete from Clearance Library", async ({
     page,
 }) => {
-    const pattern = "**/*.json";
+    const pattern = "apps/scanner_agent/*";
     const reason = "OPTIONAL_COMPONENT_OF";
     const comment = "Test create path exclusion, delete from Clearance Library";
 
     // Create a path exclusion
-    await page.getByRole("link", { name: "package-lock.json" }).click();
-    await page.getByTestId("path-exclusion-similar").click();
-    await expect(page.getByLabel("Pattern")).toHaveValue(pattern);
+    await page.getByText("apps").click();
+    await page.getByText("scanner_agent").click();
+    await page.getByTestId("selection-mode-toggle").click();
+    await page.locator('[id="\\32 68"]').click();
+    await page.locator('[id="\\32 69"]').click();
+    await page.locator('[id="\\32 80"]').click();
+    await page.locator('[id="\\32 81"]').click();
+    await page.locator('[id="\\32 82"]').click();
+    await page.getByTestId("create-path-exclusion").click();
+    await expect(page.getByTestId("glob-pattern")).toHaveValue(pattern);
     await page.getByLabel("Reason").click();
     await page.getByLabel(reason, { exact: true }).click();
     await page.getByLabel("Comment").click();

--- a/apps/clearance_ui/tests/unit/treeSelectionTS.test.ts
+++ b/apps/clearance_ui/tests/unit/treeSelectionTS.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+// Unit tests for some helper functions of tree selection utils
+
+import {
+    generateGlobPattern,
+    isPathSubset,
+    removeInnerSubstitutions,
+} from "@/helpers/treeSelectionUtils";
+
+describe("Tree selection helper function tests", () => {
+    it("Finds that path1 is a subset of path2", () => {
+        const paths = ["dir1/dir2/**", "dir1/dir2/dir3/**"];
+        expect(isPathSubset(paths[0], paths[1])).toBe(true);
+    });
+    it("Finds that path1 is not a subset of path2", () => {
+        const paths = ["dir1/dir2/**", "dir1/dir4/**"];
+        expect(isPathSubset(paths[0], paths[1])).toBe(false);
+    });
+    it("Removes inner substitutions from a path", () => {
+        const paths = [
+            "dir1/dir2/**",
+            "dir1/dir2/dir3/**",
+            "dir1/dir2/dir4/**",
+            "dir1/dir2/dir3/dir4/**",
+        ];
+        expect(removeInnerSubstitutions(paths)).toEqual(["dir1/dir2/**"]);
+    });
+    it("Doesn't remove any substitutions when no inner paths exist", () => {
+        const paths = ["dir1/dir2/**", "dir1/dir3/**"];
+        expect(removeInnerSubstitutions(paths)).toEqual(paths);
+    });
+    it("Generates a glob pattern from a set of filepaths", () => {
+        const paths = [
+            "dir1/**",
+            "dir1/dir2/file1.ts",
+            "dir1/dir2/file2.ts",
+            "dir1/dir2/file3.ts",
+        ];
+        expect(generateGlobPattern(paths)).toEqual(
+            "{dir1/**,dir1/dir2/{file1.ts,file2.ts,file3.ts}}",
+        );
+    });
+});


### PR DESCRIPTION
This PR does a complete refactor to clearance tools: now we have only four buttons to use:
- selection mode, which allows the user to freely choose from the filetree those folders and files that are needed for a clearance item (bulk license conclusion, path exclusion)
- reset selection filter
- when the user is happy with the selection, he can push the BulkC or PathE button, where the glob pattern matching his selections has been pre-written
- after the clearance item is pushed to the database, the selection filter and glob pattern are reset

Note 1: If the user selects all files in a folder, this is automatically recognized a a glob pattern path/to/files/*, whereas if a whole folder is selected, it leads to glob pattern path/to/files/**.

Note 2: Even if the UI pre-creates the glob pattern, it is up to the user to still edit it before doing the clearance, if he so chooses.