### PR TITLE
Do 591 fix selection state not syncing from filtering to main view

### DIFF
--- a/apps/clearance_ui/src/helpers/findNodesWithLicense.ts
+++ b/apps/clearance_ui/src/helpers/findNodesWithLicense.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 HH Partners
+//
+// SPDX-License-Identifier: MIT
+
+import { TreeNode } from "@/types";
+
+export const findNodesWithLicense = (
+    root: TreeNode[],
+    licenseSearchText: string,
+): TreeNode[] => {
+    const nodesWithLicense: TreeNode[] = [];
+
+    const recursiveSearch = (node: TreeNode): void => {
+        // Check if the node itself has the license
+        const hasLicense = node.file?.licenseFindings?.some((licenseFinding) =>
+            licenseFinding.licenseExpressionSPDX
+                ?.toLowerCase()
+                .includes(licenseSearchText.toLowerCase()),
+        );
+
+        if (hasLicense) {
+            nodesWithLicense.push(node);
+        }
+
+        // Check children
+        if (node.children) {
+            for (const child of node.children) {
+                recursiveSearch(child);
+            }
+        }
+    };
+
+    for (const node of root) {
+        recursiveSearch(node);
+    }
+
+    return nodesWithLicense;
+};

--- a/apps/clearance_ui/tests/e2e/logged-as-test-user/bulk-conclusion.spec.ts
+++ b/apps/clearance_ui/tests/e2e/logged-as-test-user/bulk-conclusion.spec.ts
@@ -46,6 +46,8 @@ test("create bulk conclusion, delete from Main UI", async ({ page }) => {
     console.log("bulk license conclusion created");
 
     // Delete the same bulk license conclusion
+    await page.getByRole("button", { name: "Expand" }).click();
+    await page.getByRole("button", { name: "Collapse" }).click();
     await page.getByText("apps").click();
     await page.getByText("scanner_agent").click();
     await page.getByText(".eslintrc.js").click();
@@ -159,6 +161,8 @@ test("create bulk conclusion, edit, and delete from Main UI", async ({
     console.log("bulk license conclusion created");
 
     // Edit the bulk conclusion
+    await page.getByRole("button", { name: "Expand" }).click();
+    await page.getByRole("button", { name: "Collapse" }).click();
     await page.getByText("apps").click();
     await page.getByText("api").click();
     await page.getByText("src").click();


### PR DESCRIPTION
This PR changes the way package filetree is filtered in Clearance UI, and by doing that, the selection state will now be kept in sync, whether in license filtering or unfiltered mode.