### PR TITLE
DO 617 Change kcUserId to a non-null field

### DIFF
--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -247,6 +247,7 @@ export const createLicenseConclusion = async (input: {
     contextPurl: string;
     fileSha256: string;
     userId: number;
+    kcUserId: string;
 }): Promise<LicenseConclusion> => {
     let retries = initialRetryCount;
     let licenseConclusion: LicenseConclusion | null = null;
@@ -304,6 +305,7 @@ export const createBulkConclusion = async (input: {
     local: boolean | undefined;
     packageId: number;
     userId: number;
+    kcUserId: string;
 }): Promise<BulkConclusion> => {
     let retries = initialRetryCount;
     let bulkConclusion: BulkConclusion | null = null;
@@ -445,6 +447,7 @@ export const createPathExclusion = async (input: {
     comment: string | null;
     packageId: number;
     userId: number;
+    kcUserId: string;
 }): Promise<PathExclusion> => {
     let retries = initialRetryCount;
     let pathExclusion: PathExclusion | null = null;

--- a/apps/api/src/routes/admin_router.ts
+++ b/apps/api/src/routes/admin_router.ts
@@ -24,6 +24,7 @@ adminRouter.post("/user", async (req, res) => {
             : role == "ADMIN"
               ? "GOLD"
               : "SILVER";
+        const kcUserId = req.body.keycloakUserId;
         const user = await dbQueries.findUserByUsername(username);
         if (user) {
             res.status(400).send({ message: "User already exists" });
@@ -46,20 +47,22 @@ adminRouter.post("/user", async (req, res) => {
                     const token = req.body.token
                         ? req.body.token
                         : crypto.randomBytes(16).toString("hex");
-                    await dbQueries.createUser({
+                    const newUser = await dbQueries.createUser({
                         username,
                         hashedPassword,
                         salt,
                         token,
                         role,
                         subscription,
+                        kcUserId,
                     });
                     res.send({
-                        username: req.body.username,
+                        username: newUser.username,
                         password: req.body.password,
-                        role: role,
+                        role: newUser.role,
                         subscription: subscription,
                         token: token,
+                        keycloakUserId: newUser.kcUserId,
                     });
                 },
             );

--- a/apps/api/src/routes/user_router.ts
+++ b/apps/api/src/routes/user_router.ts
@@ -338,6 +338,7 @@ userRouter.post(
                 contextPurl: contextPurl,
                 fileSha256: req.params.sha256,
                 userId: req.user.id,
+                kcUserId: req.user.kcUserId,
             });
 
             res.status(200).json({
@@ -633,6 +634,7 @@ userRouter.post("/packages/:purl/bulk-conclusions", async (req, res) => {
             local: req.body.local,
             packageId: packageId,
             userId: user.id,
+            kcUserId: user.kcUserId,
         });
 
         let mathchedPathsCount = 0;
@@ -657,6 +659,7 @@ userRouter.post("/packages/:purl/bulk-conclusions", async (req, res) => {
                         fileSha256: fileTree.fileSha256,
                         userId: user.id,
                         bulkConclusionId: bulkConclusion.id,
+                        kcUserId: user.kcUserId,
                     });
             }
         }
@@ -882,6 +885,7 @@ userRouter.put("/bulk-conclusions/:id", async (req, res) => {
                         fileSha256: fileTree.fileSha256,
                         userId: req.user.id,
                         bulkConclusionId: bulkConclusionWithRelations.id,
+                        kcUserId: req.user.kcUserId,
                     });
                 }
             }
@@ -1257,6 +1261,7 @@ userRouter.post("/packages/:purl/path-exclusions", async (req, res) => {
             comment: req.body.comment || null,
             packageId: packageId,
             userId: user.id,
+            kcUserId: user.kcUserId,
         });
 
         res.status(200).json({

--- a/apps/clearance_ui/src/components/user_management/AddUserForm.tsx
+++ b/apps/clearance_ui/src/components/user_management/AddUserForm.tsx
@@ -34,6 +34,7 @@ const addUserFormSchema = z.object({
     password: getPasswordSchema(true),
     role: z.enum(["USER", "ADMIN"]),
     subscription: z.enum(["SILVER", "GOLD"]),
+    keycloakUserId: z.string().uuid(),
 });
 
 type AddUserDataType = z.infer<typeof addUserFormSchema>;
@@ -46,6 +47,7 @@ type AddUserFormProps = {
             role: string;
             subscription: string;
             token: string;
+            keycloakUserId: string;
         } | null,
     ) => void;
 };
@@ -66,9 +68,7 @@ const AddUserForm = ({ onNewUserCreated }: AddUserFormProps) => {
         isSuccess,
         reset,
         mutate: addUser,
-    } = adminHooks.useMutation(
-        "post",
-        "/user",
+    } = adminHooks.useAddUser(
         {
             withCredentials: true,
         },
@@ -217,6 +217,19 @@ const AddUserForm = ({ onNewUserCreated }: AddUserFormProps) => {
                                         </SelectItem>
                                     </SelectContent>
                                 </Select>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="keycloakUserId"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Keycloak User ID</FormLabel>
+                                <FormControl>
+                                    <Input {...field} />
+                                </FormControl>
                                 <FormMessage />
                             </FormItem>
                         )}

--- a/packages/database/prisma/migrations/20240311101418_set_kc_user_id_field_to_not_null/migration.sql
+++ b/packages/database/prisma/migrations/20240311101418_set_kc_user_id_field_to_not_null/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - Made the column `kcUserId` on table `BulkConclusion` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `kcUserId` on table `LicenseConclusion` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `kcUserId` on table `PathExclusion` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `kcUserId` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "BulkConclusion" ALTER COLUMN "kcUserId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "LicenseConclusion" ALTER COLUMN "kcUserId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "PathExclusion" ALTER COLUMN "kcUserId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "kcUserId" SET NOT NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -127,7 +127,7 @@ model BulkConclusion {
   userId Int
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  kcUserId String? @db.Uuid
+  kcUserId String @db.Uuid
 
   licenseConclusions LicenseConclusion[]
 
@@ -154,7 +154,7 @@ model LicenseConclusion {
   userId Int
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  kcUserId String? @db.Uuid
+  kcUserId String @db.Uuid
 
   bulkConclusionId Int?
   bulkConclusion   BulkConclusion? @relation(fields: [bulkConclusionId], references: [id], onDelete: Cascade)
@@ -229,7 +229,7 @@ model PathExclusion {
   userId Int
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  kcUserId String? @db.Uuid
+  kcUserId String @db.Uuid
 
   @@index([packageId])
   @@index([userId])
@@ -300,7 +300,7 @@ model User {
   token          String?       @unique
   role           Role          @default(USER)
   subscription   Subscription? @default(SILVER)
-  kcUserId       String?       @db.Uuid
+  kcUserId       String        @db.Uuid
 
   licenseConclusions LicenseConclusion[]
   PathExclusions     PathExclusion[]

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -42,6 +42,7 @@ async function main() {
             token: "test_token",
             salt: testUserSalt,
             hashedPassword: testUserHashedPassword,
+            kcUserId: "8cd34049-ddf4-43ee-87c1-0674190db157",
         },
     });
 
@@ -63,6 +64,7 @@ async function main() {
             token: "test_token2",
             salt: testUser2Salt,
             hashedPassword: testUser2HashedPassword,
+            kcUserId: "d3eccda9-c429-4f09-bfda-ea8d8d21123b",
         },
     });
 
@@ -85,6 +87,7 @@ async function main() {
             role: "ADMIN",
             salt: testAdminUserSalt,
             hashedPassword: testAdminUserHashedPassword,
+            kcUserId: "483643cc-830a-426f-8ff8-8a37fbd62709",
         },
     });
 

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -1925,6 +1925,7 @@ declare const adminAPI: [
         method: "post";
         path: "/user";
         description: "Add user";
+        alias: "AddUser";
         parameters: [
             {
                 name: "body";
@@ -1941,6 +1942,7 @@ declare const adminAPI: [
                             string
                         >;
                         password: zod.ZodEffects<zod.ZodString, string, string>;
+                        keycloakUserId: zod.ZodString;
                         role: zod.ZodOptional<zod.ZodEnum<["ADMIN", "USER"]>>;
                         subscription: zod.ZodOptional<
                             zod.ZodEnum<["SILVER", "GOLD"]>
@@ -1952,6 +1954,7 @@ declare const adminAPI: [
                     {
                         username: string;
                         password: string;
+                        keycloakUserId: string;
                         role?: "ADMIN" | "USER" | undefined;
                         subscription?: "SILVER" | "GOLD" | undefined;
                         token?: string | undefined;
@@ -1959,6 +1962,7 @@ declare const adminAPI: [
                     {
                         username: string;
                         password: string;
+                        keycloakUserId: string;
                         role?: "ADMIN" | "USER" | undefined;
                         subscription?: "SILVER" | "GOLD" | undefined;
                         token?: string | undefined;
@@ -1970,6 +1974,7 @@ declare const adminAPI: [
             {
                 username: zod.ZodString;
                 password: zod.ZodString;
+                keycloakUserId: zod.ZodString;
                 role: zod.ZodEnum<["ADMIN", "USER"]>;
                 subscription: zod.ZodEnum<["SILVER", "GOLD"]>;
                 token: zod.ZodString;
@@ -1979,6 +1984,7 @@ declare const adminAPI: [
             {
                 username: string;
                 password: string;
+                keycloakUserId: string;
                 role: "ADMIN" | "USER";
                 subscription: "SILVER" | "GOLD";
                 token: string;
@@ -1986,6 +1992,7 @@ declare const adminAPI: [
             {
                 username: string;
                 password: string;
+                keycloakUserId: string;
                 role: "ADMIN" | "USER";
                 subscription: "SILVER" | "GOLD";
                 token: string;
@@ -17938,6 +17945,7 @@ declare const dosAPI: [
         method: "post";
         path: "/admin/user";
         description: "Add user";
+        alias: "AddUser";
         parameters: [
             {
                 name: "body";
@@ -17954,6 +17962,7 @@ declare const dosAPI: [
                             string
                         >;
                         password: zod.ZodEffects<zod.ZodString, string, string>;
+                        keycloakUserId: zod.ZodString;
                         role: zod.ZodOptional<zod.ZodEnum<["ADMIN", "USER"]>>;
                         subscription: zod.ZodOptional<
                             zod.ZodEnum<["SILVER", "GOLD"]>
@@ -17965,6 +17974,7 @@ declare const dosAPI: [
                     {
                         username: string;
                         password: string;
+                        keycloakUserId: string;
                         role?: "ADMIN" | "USER" | undefined;
                         subscription?: "SILVER" | "GOLD" | undefined;
                         token?: string | undefined;
@@ -17972,6 +17982,7 @@ declare const dosAPI: [
                     {
                         username: string;
                         password: string;
+                        keycloakUserId: string;
                         role?: "ADMIN" | "USER" | undefined;
                         subscription?: "SILVER" | "GOLD" | undefined;
                         token?: string | undefined;
@@ -17983,6 +17994,7 @@ declare const dosAPI: [
             {
                 username: zod.ZodString;
                 password: zod.ZodString;
+                keycloakUserId: zod.ZodString;
                 role: zod.ZodEnum<["ADMIN", "USER"]>;
                 subscription: zod.ZodEnum<["SILVER", "GOLD"]>;
                 token: zod.ZodString;
@@ -17992,6 +18004,7 @@ declare const dosAPI: [
             {
                 username: string;
                 password: string;
+                keycloakUserId: string;
                 role: "ADMIN" | "USER";
                 subscription: "SILVER" | "GOLD";
                 token: string;
@@ -17999,6 +18012,7 @@ declare const dosAPI: [
             {
                 username: string;
                 password: string;
+                keycloakUserId: string;
                 role: "ADMIN" | "USER";
                 subscription: "SILVER" | "GOLD";
                 token: string;

--- a/packages/validation-helpers/src/api/apis/admin.ts
+++ b/packages/validation-helpers/src/api/apis/admin.ts
@@ -27,6 +27,7 @@ export const adminAPI = makeApi([
         method: "post",
         path: "/user",
         description: "Add user",
+        alias: "AddUser",
         parameters: [
             {
                 name: "body",

--- a/packages/validation-helpers/src/api/schemas/admin_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/admin_schemas.ts
@@ -22,6 +22,7 @@ export const DeleteScanResultsRes = z.object({
 export const PostUserReq = z.object({
     username: getUsernameSchema(true),
     password: getPasswordSchema(true),
+    keycloakUserId: z.string().uuid(),
     role: z.enum(["ADMIN", "USER"]).optional(),
     subscription: z.enum(["SILVER", "GOLD"]).optional(),
     token: z.string().optional(),
@@ -30,6 +31,7 @@ export const PostUserReq = z.object({
 export const PostUserRes = z.object({
     username: z.string(),
     password: z.string(),
+    keycloakUserId: z.string().uuid(),
     role: z.enum(["ADMIN", "USER"]),
     subscription: z.enum(["SILVER", "GOLD"]),
     token: z.string(),


### PR DESCRIPTION
Now that the keycloak user id has been added to the rows in the User, LicenseConclusion, BulkConclusion, and PathExclusion tables in the database, the field can be changed to not null. New rows will now be added with the kcUserId, taken now from the User table, and later on this will be changed to it being queried straight from the Keycloak server.