### PR TITLE
bug(ui): Fix pattern validation in forms

### DIFF
--- a/apps/clearance_ui/src/schemes/pattern_schema.ts
+++ b/apps/clearance_ui/src/schemes/pattern_schema.ts
@@ -8,9 +8,21 @@ import { z } from "zod";
 export const patternGlobSchema = z
     .string()
     .min(1, "Pattern cannot be empty")
-    .refine((pattern) => isGlob(pattern), {
-        message: "Pattern is not a valid glob pattern",
-    })
+    .refine(
+        (pattern) => {
+            // Check if the pattern is a valid glob or matches a single file in a filepath:
+            //   ([.\w-]+\/)* matches zero or more occurrences of a ".", "-", "\w" characters (directory) followed by a slash
+            //   [.\w-]+ matches the file name with ".", "-", or "\w" allowed
+            //   (\.\w+)? makes the file extension part optional
+            return (
+                isGlob(pattern) || /^([.\w-]+\/)*[.\w-]+(\.\w+)?$/.test(pattern)
+            );
+        },
+        {
+            message:
+                "Pattern is not a valid glob pattern or a single file path",
+        },
+    )
     .refine((pattern) => pattern !== "**", {
         message: "You cannot do a bulk conclusion for all files in a package",
     });


### PR DESCRIPTION
Extend pattern validation rules to allow for non-glob patterns, which in effect match only single files.