### PR TITLE
Do 598 license dots should never hide the file name

### DIFF
--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
@@ -13,6 +13,12 @@ import {
 } from "react-icons/bs";
 import { MdArrowDropDown, MdArrowRight } from "react-icons/md";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import LicenseHitCircle from "@/components/main_ui/inspector/package_inspector/LicenseHitCircle";
 import { cn } from "@/lib/utils";
 import type { TreeNode } from "@/types/index";
@@ -192,7 +198,20 @@ const Node = ({
                         // Render the first 10 indicators and an ellipsis when there are more than 10
                         <>
                             {licenseFindingIndicators.slice(0, 10)}
-                            <ThreeDots className="ml-1 text-gray-400" />
+                            <TooltipProvider>
+                                <Tooltip>
+                                    <TooltipTrigger className="ml-1">
+                                        <ThreeDots className="text-gray-400" />
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" align="end">
+                                        <div className="w-full p-1">
+                                            {licenseFindingIndicators.length -
+                                                10}
+                                            {" more license matches"}
+                                        </div>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
                         </>
                     )}
                 </span>

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/Node.tsx
@@ -9,6 +9,7 @@ import {
     BsFileText as FileText,
     BsFolder as FolderClosed,
     BsFolder2Open as FolderOpen,
+    BsThreeDots as ThreeDots,
 } from "react-icons/bs";
 import { MdArrowDropDown, MdArrowRight } from "react-icons/md";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -184,7 +185,16 @@ const Node = ({
             </span>
             {isLeaf && licenseFindingIndicators.length > 0 && (
                 <span className="flex flex-row items-center">
-                    {licenseFindingIndicators}
+                    {licenseFindingIndicators.length <= 10 ? (
+                        // Render all indicators when there are 10 or fewer
+                        licenseFindingIndicators
+                    ) : (
+                        // Render the first 10 indicators and an ellipsis when there are more than 10
+                        <>
+                            {licenseFindingIndicators.slice(0, 10)}
+                            <ThreeDots className="ml-1 text-gray-400" />
+                        </>
+                    )}
                 </span>
             )}
         </div>


### PR DESCRIPTION
This PR limits the coloured circles indicating the license matches in a file to 10, which is a pretty fair number, taking into consideration that the package filetree probably cannot be kept very wide in the Main UI.  When there are more than 10 license matches, an ellipsis is shown, which, when hovered over with a mouse, shows how many more matches there are for this file.

All license matches of a file are always seen in the rightmost (clearance) part of the Main UI, where they can also be investigated individually, so this PR is a cosmetic one, preventing the Main UI layout from breaking, especially with 3rd party notices files, in which there can be a huge number of ScanCode license matches.