### PR TITLE
chore: Turn on workflow dispatch for some wfs

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,6 +12,7 @@ on:
         # The branches below must be a subset of the branches above
         branches:
             - main
+    workflow_dispatch:
 
 jobs:
     lint:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -11,6 +11,7 @@ on:
     push:
         branches:
             - main
+    workflow_dispatch:
 
 jobs:
     prettier:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,8 @@ on:
         branches: [main, master]
     pull_request:
         branches: [main, master]
+    workflow_dispatch:
+
 jobs:
     test:
         timeout-minutes: 60

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -9,6 +9,7 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
+    workflow_dispatch:
 
 jobs:
     Reuse:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,6 +11,7 @@ on:
     pull_request:
         branches:
             - main
+    workflow_dispatch:
 
 jobs:
     unittest:


### PR DESCRIPTION
With this PR, workflows can be uniquelly also run in Github in manual mode to a branch, even without a PR or draft PR.