### PR TITLE
Do 632 path exclusion with {} needs a prepending path

### DIFF
--- a/apps/clearance_ui/src/components/common/edit_item/BulkConclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/common/edit_item/BulkConclusionEditForm.tsx
@@ -42,11 +42,11 @@ import ConclusionSPDX from "@/components/common/ConclusionSPDX";
 import { findMatchingPaths } from "@/helpers/findMatchingPaths";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
 import { cn } from "@/lib/utils";
-import { patternGlobSchema } from "@/schemes/pattern_schema";
+import { bcPatternGlobSchema } from "@/schemes/pattern_schema";
 import { concludedLicenseExpressionSPDXSchema } from "@/schemes/spdx_schema";
 
 const bulkConclusionFormSchema = z.object({
-    pattern: patternGlobSchema,
+    pattern: bcPatternGlobSchema,
     concludedLicenseSPDX: concludedLicenseExpressionSPDXSchema,
     concludedLicenseList: concludedLicenseExpressionSPDXSchema,
     comment: z.string(),

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/BulkConclusionForm.tsx
@@ -42,11 +42,11 @@ import ConclusionSPDX from "@/components/common/ConclusionSPDX";
 import { findMatchingPaths } from "@/helpers/findMatchingPaths";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
 import { cn } from "@/lib/utils";
-import { patternGlobSchema } from "@/schemes/pattern_schema";
+import { bcPatternGlobSchema } from "@/schemes/pattern_schema";
 import { concludedLicenseExpressionSPDXSchema } from "@/schemes/spdx_schema";
 
 const bulkConclusionFormSchema = z.object({
-    pattern: patternGlobSchema,
+    pattern: bcPatternGlobSchema,
     concludedLicenseSPDX: concludedLicenseExpressionSPDXSchema,
     concludedLicenseList: concludedLicenseExpressionSPDXSchema,
     comment: z.string(),

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
@@ -34,10 +34,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { toPathPurl } from "@/helpers/pathParamHelpers";
-import { patternGlobSchema } from "@/schemes/pattern_schema";
+import { pePatternGlobSchema } from "@/schemes/pattern_schema";
 
 const exclusionFormSchema = z.object({
-    pattern: patternGlobSchema,
+    pattern: pePatternGlobSchema,
     reason: z.string().min(1, "Please select a valid reason from this list"),
     comment: z.string().optional(),
 });

--- a/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_bulk_conclusions/BulkConclusionEditForm.tsx
@@ -36,11 +36,11 @@ import { useToast } from "@/components/ui/use-toast";
 import ConclusionLicense from "@/components/common/ConclusionLicense";
 import ConclusionSPDX from "@/components/common/ConclusionSPDX";
 import { cn } from "@/lib/utils";
-import { patternGlobSchema } from "@/schemes/pattern_schema";
+import { bcPatternGlobSchema } from "@/schemes/pattern_schema";
 import { concludedLicenseExpressionSPDXSchema } from "@/schemes/spdx_schema";
 
 const bulkConclusionFormSchema = z.object({
-    pattern: patternGlobSchema,
+    pattern: bcPatternGlobSchema,
     concludedLicenseSPDX: concludedLicenseExpressionSPDXSchema,
     concludedLicenseList: concludedLicenseExpressionSPDXSchema,
     comment: z.string(),

--- a/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/package_path_exclusions/PathExclusionEditForm.tsx
@@ -35,10 +35,10 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
-import { patternGlobSchema } from "@/schemes/pattern_schema";
+import { pePatternGlobSchema } from "@/schemes/pattern_schema";
 
 const exclusionFormSchema = z.object({
-    pattern: patternGlobSchema,
+    pattern: pePatternGlobSchema,
     reason: z.string().min(1, "Please select a valid reason from this list"),
     comment: z.string().optional(),
 });

--- a/apps/clearance_ui/src/helpers/validateCurlyBracesInGlob.ts
+++ b/apps/clearance_ui/src/helpers/validateCurlyBracesInGlob.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+export function validateCurlyBracesInGlob(globPattern: string): boolean {
+    // In case no curly braces are used, to an early return with true
+    if (!globPattern.includes("{")) {
+        return true;
+    }
+    // Check that when using curly braces {} anywhere in the glob pattern,
+    // it always has a prepending non-empty path. Examples of valid patterns:
+    //   dir1/dir2/{file1,file2}
+    //   dir1/dir2/{file1, dir3/{file3,file4}}
+    const regex = /^[^{]*\/.*{.*}/;
+    return regex.test(globPattern);
+}

--- a/apps/clearance_ui/src/schemes/pattern_schema.ts
+++ b/apps/clearance_ui/src/schemes/pattern_schema.ts
@@ -5,7 +5,29 @@
 import isGlob from "is-glob";
 import { z } from "zod";
 
-export const patternGlobSchema = z
+export const bcPatternGlobSchema = z
+    .string()
+    .min(1, "Pattern cannot be empty")
+    .refine(
+        (pattern) => {
+            // Check if the pattern is a valid glob or matches a single file in a filepath:
+            //   ([.\w-]+\/)* matches zero or more occurrences of a ".", "-", "\w" characters (directory) followed by a slash
+            //   [.\w-]+ matches the file name with ".", "-", or "\w" allowed
+            //   (\.\w+)? makes the file extension part optional
+            return (
+                isGlob(pattern) || /^([.\w-]+\/)*[.\w-]+(\.\w+)?$/.test(pattern)
+            );
+        },
+        {
+            message:
+                "Pattern is not a valid glob pattern or a single file path",
+        },
+    )
+    .refine((pattern) => pattern !== "**", {
+        message: "You cannot do a bulk conclusion for all files in a package",
+    });
+
+export const pePatternGlobSchema = z
     .string()
     .min(1, "Pattern cannot be empty")
     .refine(

--- a/apps/clearance_ui/src/schemes/pattern_schema.ts
+++ b/apps/clearance_ui/src/schemes/pattern_schema.ts
@@ -4,6 +4,7 @@
 
 import isGlob from "is-glob";
 import { z } from "zod";
+import { validateCurlyBracesInGlob } from "@/helpers/validateCurlyBracesInGlob";
 
 export const bcPatternGlobSchema = z
     .string()
@@ -32,7 +33,7 @@ export const pePatternGlobSchema = z
     .min(1, "Pattern cannot be empty")
     .refine(
         (pattern) => {
-            // Check if the pattern is a valid glob or matches a single file in a filepath:
+            // Check that the pattern is a valid glob or matches a single file in a filepath:
             //   ([.\w-]+\/)* matches zero or more occurrences of a ".", "-", "\w" characters (directory) followed by a slash
             //   [.\w-]+ matches the file name with ".", "-", or "\w" allowed
             //   (\.\w+)? makes the file extension part optional
@@ -45,6 +46,17 @@ export const pePatternGlobSchema = z
                 "Pattern is not a valid glob pattern or a single file path",
         },
     )
+    .refine(
+        (pattern) => {
+            // Check that whenever using curly braces in a glob pattern for path exclusion,
+            // it always has a prepending non-empty path.
+            return validateCurlyBracesInGlob(pattern);
+        },
+        {
+            message:
+                "Due to ORT limitations, this pattern is invalid. Possible reasons: 1) You cannot exclude more than one file from root directory at once; 2) You cannot exclude files from several directories at once",
+        },
+    )
     .refine((pattern) => pattern !== "**", {
-        message: "You cannot do a bulk conclusion for all files in a package",
+        message: "You cannot do a path exclusion for all files in a package",
     });

--- a/apps/clearance_ui/tests/unit/curlyBracesTS.test.ts
+++ b/apps/clearance_ui/tests/unit/curlyBracesTS.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+// Test the curly braces in the glob pattern
+import { validateCurlyBracesInGlob } from "@/helpers/validateCurlyBracesInGlob";
+
+describe("Curly braces in glob pattern", () => {
+    it("Matches properly curly braces with a prepending path", () => {
+        expect(validateCurlyBracesInGlob("dir1/dir2/{file1,file2}")).toBe(true);
+    });
+
+    it("Doesn't match when there is no prepending path", () => {
+        expect(validateCurlyBracesInGlob("{file1,file2}")).toBe(false);
+    });
+
+    it("Matches properly nested curly braces", () => {
+        expect(
+            validateCurlyBracesInGlob("dir1/dir2/{file1, dir3/{file3,file4}}"),
+        ).toBe(true);
+    });
+
+    it("Doesn't match nested curly braces without a prepending path", () => {
+        expect(validateCurlyBracesInGlob("{file1, dir3/{file3,file4}}")).toBe(
+            false,
+        );
+    });
+});


### PR DESCRIPTION
ORT uses [AntPathMatcher](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html) for path matching with globs, and it seems to always need a prepending path for globs which use the object listing property (implemented with curly braces {...}).

Thus, while these will work:
```
dir1/dir2/{file1,file2}
dir1/dir2/{file1,dir3/{file2,file3}}
```

these will silently fail, failing to apply the path exclusion properly:
```
{file1,file2}
{file1,dir2/{file2,file3}}
```

This PR tightens the validation of path exclusion glob patterns by checking that curly braces always have a prepending path attached to them, and if not, giving an informative error message to the user as to why the glob pattern is not acceptable.

Note that due to this limitation, it is impossible to do these path exclusions in the Clearance UI currently:
1. Exclude more than one file from the root directory at the same time (-> this would lead to pattern `{file1,file2}`).
2. Exclude files from more than one directory at the same time (-> this would lead to pattern `{dir1/dir2/{file1,file2},dir3/file3}`

Neither pattern is acceptable, because they include at least one `{...}` pattern without a prepending path. 