### PR TITLE
fix(validation): Keyword "exception" required with LicenseRef

### DIFF
--- a/apps/clearance_ui/tests/unit/isValidConcludedExpressionTS.test.ts
+++ b/apps/clearance_ui/tests/unit/isValidConcludedExpressionTS.test.ts
@@ -42,4 +42,14 @@ describe("isValidConcludedExpression tests", () => {
             errWord: null,
         });
     });
+
+    it("Returns isValid: false and errWord: WITH for an invalid LicenseRef (not an exception) used with WITH", () => {
+        const result = isValidConcludedExpression(
+            "GPL-2.0-only WITH LicenseRef-invalid",
+        );
+        expect(result).toEqual({
+            isValid: false,
+            errWord: null,
+        });
+    });
 });

--- a/packages/spdx-validation/src/parse.ts
+++ b/packages/spdx-validation/src/parse.ts
@@ -64,12 +64,19 @@ export const parse = (tokens: Token[]): LicenseInfo | ConjunctionInfo => {
             const t = token();
             // This change is here to comply with the current strictness setting
             // for license checking in DOS: license WITH LicenseRef is allowed,
+            // if it includes the "exception" keyword,
             // even if not strictly complying with SPDX rules (expecting AND).
-            if (t && (t.type === "EXCEPTION" || t.type === "LICENSEREF")) {
+            if (
+                t &&
+                (t.type === "EXCEPTION" ||
+                    (t.type === "LICENSEREF" && t.string.includes("exception")))
+            ) {
                 next();
                 return t.string;
             }
-            throw new Error("Expected exception or LicenseRef after `WITH`");
+            throw new Error(
+                "Expected exception or LicenseRef with `...exception...` after `WITH`",
+            );
         }
     }
 


### PR DESCRIPTION
When license conclusion "license WITH LicenseRef" is used, the keyword WITH is only accepted, if the LicenseRef includes the keyword "exception".