### PR TITLE
Do 649 add path exclusions optionally for filetrees query

### DIFF
--- a/apps/api/src/helpers/db_error_codes.ts
+++ b/apps/api/src/helpers/db_error_codes.ts
@@ -507,4 +507,15 @@ export const dbErrorCodeResMessagesMap: Map<
             severity: "LOW",
         },
     ],
+    [
+        "P2035",
+        {
+            message:
+                "Database query error: Too many bind variables in prepared statement.",
+            description: "Too many bind variables in prepared statement.",
+            requiresAction: true,
+            requiresTracking: false,
+            severity: "CRITICAL",
+        },
+    ],
 ]);

--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -2001,6 +2001,44 @@ export const getPathExclusionsByPackagePurl = async (
     return packageObj.pathExclusions;
 };
 
+export const getPathExclusionPatternsByPackagePurl = async (
+    purl: string,
+): Promise<string[]> => {
+    let retries = initialRetryCount;
+    let patterns: string[] = [];
+
+    while (retries > 0) {
+        try {
+            patterns = await prisma.pathExclusion
+                .findMany({
+                    where: {
+                        package: {
+                            purl: purl,
+                        },
+                    },
+                    select: {
+                        pattern: true,
+                    },
+                })
+                .then((pathExclusions: { pattern: string }[]) => {
+                    return pathExclusions.map((pathExclusion) => {
+                        return pathExclusion.pattern;
+                    });
+                });
+            break;
+        } catch (error) {
+            console.log("Error with trying to find PathExclusions: " + error);
+            handleError(error);
+            retries--;
+
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    return patterns;
+};
+
 export const getPackageScanResults = async (purl: string) => {
     let retries = initialRetryCount;
     let results = null;

--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -53,6 +53,7 @@ const handleError = (error: unknown) => {
             case "P2004":
             case "P2015":
             case "P2025":
+            case "P2035":
                 throw error;
             default:
                 break;

--- a/apps/api/src/helpers/temp/db_queries.ts
+++ b/apps/api/src/helpers/temp/db_queries.ts
@@ -53,6 +53,7 @@ const handleError = (error: unknown) => {
             case "P2004":
             case "P2015":
             case "P2025":
+            case "P2035":
                 throw error;
             default:
                 break;

--- a/apps/api/src/routes/temp/user_router.ts
+++ b/apps/api/src/routes/temp/user_router.ts
@@ -1659,14 +1659,14 @@ userRouter.get("/packages/:purl/filetrees", async (req, res) => {
             );
         }
 
-        if (filetrees) {
-            res.status(200).json({
-                filetrees: filetrees,
-            });
-        }
+        res.status(200).json({
+            filetrees: filetrees,
+        });
     } catch (error) {
         console.log("Error: ", error);
-        res.status(500).json({ message: "Internal server error" });
+        // Get error status code and message based on whether error is a Prisma error or an unknown error
+        const err = await getErrorCodeAndMessage(error);
+        res.status(err.statusCode).json({ message: err.message });
     }
 });
 

--- a/apps/api/src/routes/temp/user_router.ts
+++ b/apps/api/src/routes/temp/user_router.ts
@@ -1650,17 +1650,68 @@ userRouter.get("/packages/count", async (req, res) => {
 
 userRouter.get("/packages/:purl/filetrees", async (req, res) => {
     try {
+        const timeString =
+            new Date().toISOString() + " started filetrees query lasted: ";
+        console.time(timeString);
+
         const purl = req.params.purl;
         const filetrees = await dbQueries.findFileTreesByPackagePurl(purl);
 
+        const patterns =
+            await dbQueries.getPathExclusionPatternsByPackagePurl(purl);
+
+        const promises: Promise<void>[] = [];
+
+        const fileTreesWithExclusions: {
+            path: string;
+            file: {
+                licenseConclusions: {
+                    concludedLicenseExpressionSPDX: string;
+                }[];
+                licenseFindings: { licenseExpressionSPDX: string }[];
+            };
+            packageId: number;
+            fileSha256: string;
+            isExcluded?: boolean | undefined;
+        }[] = [];
+
         for (const ft of filetrees) {
-            ft.file.licenseConclusions = ft.file.licenseConclusions.filter(
-                (lc) => !(lc.local && lc.contextPurl !== purl),
-            );
+            const task = (async () => {
+                ft.file.licenseConclusions = ft.file.licenseConclusions.filter(
+                    (lc) => !(lc.local && lc.contextPurl !== purl),
+                );
+
+                let isExcluded = undefined;
+                if (req.query.includeIsExcluded) {
+                    isExcluded = false;
+                    for (const pattern of patterns) {
+                        if (minimatch(ft.path, pattern, { dot: true })) {
+                            isExcluded = true;
+                            break;
+                        }
+                    }
+                }
+
+                fileTreesWithExclusions.push({
+                    ...ft,
+                    isExcluded: isExcluded,
+                });
+            })();
+
+            promises.push(task);
+
+            if (promises.length >= 100) {
+                await Promise.all(promises);
+                promises.length = 0;
+            }
         }
 
+        await Promise.all(promises);
+
+        console.timeEnd(timeString);
+
         res.status(200).json({
-            filetrees: filetrees,
+            filetrees: fileTreesWithExclusions,
         });
     } catch (error) {
         console.log("Error: ", error);

--- a/apps/api/src/routes/user_router.ts
+++ b/apps/api/src/routes/user_router.ts
@@ -1528,14 +1528,14 @@ userRouter.get("/packages/:purl/filetrees", async (req, res) => {
             );
         }
 
-        if (filetrees) {
-            res.status(200).json({
-                filetrees: filetrees,
-            });
-        }
+        res.status(200).json({
+            filetrees: filetrees,
+        });
     } catch (error) {
         console.log("Error: ", error);
-        res.status(500).json({ message: "Internal server error" });
+        // Get error status code and message based on whether error is a Prisma error or an unknown error
+        const err = await getErrorCodeAndMessage(error);
+        res.status(err.statusCode).json({ message: err.message });
     }
 });
 

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useEffect, useRef, useState } from "react";
+import axios from "axios";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/router";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
@@ -334,11 +335,18 @@ const PackageInspector = ({ purl, path }: Props) => {
                         )}
                     </Tree>
                 )}
-                {error && (
-                    <div className="flex h-full items-center justify-center">
-                        Unable to fetch package data
-                    </div>
-                )}
+                {error &&
+                    (axios.isAxiosError(error) ? (
+                        <div className="flex h-full items-center justify-center text-red-700">
+                            Error with fetching package data:{" "}
+                            {error.response?.data.message ||
+                                "Unknown error. No message in response."}
+                        </div>
+                    ) : (
+                        <div className="flex h-full items-center justify-center">
+                            Unable to fetch package data
+                        </div>
+                    ))}
             </div>
 
             <Separator className="mb-2" />

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -9634,6 +9634,11 @@ declare const userAPI: [
                 type: "Path";
                 schema: zod.ZodString;
             },
+            {
+                name: "includeIsExcluded";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+            },
         ];
         response: zod.ZodObject<
             {
@@ -9697,6 +9702,7 @@ declare const userAPI: [
                                     }[];
                                 }
                             >;
+                            isExcluded: zod.ZodOptional<zod.ZodBoolean>;
                         },
                         "strip",
                         zod.ZodTypeAny,
@@ -9712,6 +9718,7 @@ declare const userAPI: [
                             };
                             packageId: number;
                             fileSha256: string;
+                            isExcluded?: boolean | undefined;
                         },
                         {
                             path: string;
@@ -9725,6 +9732,7 @@ declare const userAPI: [
                             };
                             packageId: number;
                             fileSha256: string;
+                            isExcluded?: boolean | undefined;
                         }
                     >,
                     "many"
@@ -9745,6 +9753,7 @@ declare const userAPI: [
                     };
                     packageId: number;
                     fileSha256: string;
+                    isExcluded?: boolean | undefined;
                 }[];
             },
             {
@@ -9760,6 +9769,7 @@ declare const userAPI: [
                     };
                     packageId: number;
                     fileSha256: string;
+                    isExcluded?: boolean | undefined;
                 }[];
             }
         >;
@@ -17146,6 +17156,11 @@ declare const dosAPI: [
                 type: "Path";
                 schema: zod.ZodString;
             },
+            {
+                name: "includeIsExcluded";
+                type: "Query";
+                schema: zod.ZodOptional<zod.ZodBoolean>;
+            },
         ];
         response: zod.ZodObject<
             {
@@ -17209,6 +17224,7 @@ declare const dosAPI: [
                                     }[];
                                 }
                             >;
+                            isExcluded: zod.ZodOptional<zod.ZodBoolean>;
                         },
                         "strip",
                         zod.ZodTypeAny,
@@ -17224,6 +17240,7 @@ declare const dosAPI: [
                             };
                             packageId: number;
                             fileSha256: string;
+                            isExcluded?: boolean | undefined;
                         },
                         {
                             path: string;
@@ -17237,6 +17254,7 @@ declare const dosAPI: [
                             };
                             packageId: number;
                             fileSha256: string;
+                            isExcluded?: boolean | undefined;
                         }
                     >,
                     "many"
@@ -17257,6 +17275,7 @@ declare const dosAPI: [
                     };
                     packageId: number;
                     fileSha256: string;
+                    isExcluded?: boolean | undefined;
                 }[];
             },
             {
@@ -17272,6 +17291,7 @@ declare const dosAPI: [
                     };
                     packageId: number;
                     fileSha256: string;
+                    isExcluded?: boolean | undefined;
                 }[];
             }
         >;
@@ -19548,6 +19568,7 @@ declare const FileTree: z.ZodObject<
                 }[];
             }
         >;
+        isExcluded: z.ZodOptional<z.ZodBoolean>;
     },
     "strip",
     z.ZodTypeAny,
@@ -19563,6 +19584,7 @@ declare const FileTree: z.ZodObject<
         };
         packageId: number;
         fileSha256: string;
+        isExcluded?: boolean | undefined;
     },
     {
         path: string;
@@ -19576,6 +19598,7 @@ declare const FileTree: z.ZodObject<
         };
         packageId: number;
         fileSha256: string;
+        isExcluded?: boolean | undefined;
     }
 >;
 type FileTreeType = z.infer<typeof FileTree>;
@@ -19641,6 +19664,7 @@ declare const PostFileTreeRes: z.ZodObject<
                             }[];
                         }
                     >;
+                    isExcluded: z.ZodOptional<z.ZodBoolean>;
                 },
                 "strip",
                 z.ZodTypeAny,
@@ -19656,6 +19680,7 @@ declare const PostFileTreeRes: z.ZodObject<
                     };
                     packageId: number;
                     fileSha256: string;
+                    isExcluded?: boolean | undefined;
                 },
                 {
                     path: string;
@@ -19669,6 +19694,7 @@ declare const PostFileTreeRes: z.ZodObject<
                     };
                     packageId: number;
                     fileSha256: string;
+                    isExcluded?: boolean | undefined;
                 }
             >,
             "many"
@@ -19689,6 +19715,7 @@ declare const PostFileTreeRes: z.ZodObject<
             };
             packageId: number;
             fileSha256: string;
+            isExcluded?: boolean | undefined;
         }[];
     },
     {
@@ -19704,6 +19731,7 @@ declare const PostFileTreeRes: z.ZodObject<
             };
             packageId: number;
             fileSha256: string;
+            isExcluded?: boolean | undefined;
         }[];
     }
 >;

--- a/packages/validation-helpers/src/api/apis/user.ts
+++ b/packages/validation-helpers/src/api/apis/user.ts
@@ -980,6 +980,11 @@ export const userAPI = makeApi([
                 type: "Path",
                 schema: commonSchemas.PathParamPurl,
             },
+            {
+                name: "includeIsExcluded",
+                type: "Query",
+                schema: commonSchemas.QueryParamFilterBoolean,
+            },
         ],
         response: schemas.PostFileTreeRes,
         errors,

--- a/packages/validation-helpers/src/api/schemas/user_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/user_schemas.ts
@@ -508,6 +508,7 @@ export const FileTree = z.object({
             }),
         ),
     }),
+    isExcluded: z.boolean().optional(),
 });
 
 export type FileTreeType = z.infer<typeof FileTree>;


### PR DESCRIPTION
This PR adds an isExcluded field in the filetrees query if it is queried with the includeIsExcluded query parameter set to true.