### PR TITLE
Do 602 fix glob not forming correctly

### DIFF
--- a/apps/clearance_ui/src/components/main_ui/inspector/clearance_inspector/DetectedLicense.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/clearance_inspector/DetectedLicense.tsx
@@ -33,29 +33,25 @@ const DetectedLicense = ({ fileSha256 }: DetectedLicenseProps) => {
                 <div className="flex h-full w-full flex-col items-start p-1">
                     <Label className="clearance-label">Detected license</Label>
                     {data?.licenseFindings[0] ? (
-                        <p className="h-full w-full overflow-auto p-1 text-xs">
+                        <div className="h-full w-full overflow-auto p-1 text-xs">
                             {data.licenseFindings.map((license) => (
                                 <span key={license.id}>
-                                    <>
-                                        <span className="font-bold">
-                                            {
-                                                new Date(license.updatedAt)
-                                                    .toISOString()
-                                                    .split("T")[0]
-                                            }
-                                            :{" "}
-                                        </span>
-                                        {license.licenseExpressionSPDX}
-                                        <CopyToClipboard
-                                            copyText={
-                                                license.licenseExpressionSPDX
-                                            }
-                                        />
-                                        <br />
-                                    </>
+                                    <span className="font-bold">
+                                        {
+                                            new Date(license.updatedAt)
+                                                .toISOString()
+                                                .split("T")[0]
+                                        }
+                                        :{" "}
+                                    </span>
+                                    {license.licenseExpressionSPDX}
+                                    <CopyToClipboard
+                                        copyText={license.licenseExpressionSPDX}
+                                    />
+                                    <br />
                                 </span>
                             ))}
-                        </p>
+                        </div>
                     ) : (
                         <p className="h-full w-full overflow-auto rounded-md border p-1 text-xs">
                             No license detected

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/ExclusionForm.tsx
@@ -75,6 +75,7 @@ const ExclusionForm = ({
         defaultValues,
     });
     const pathPurl = toPathPurl(purl);
+    const keyFileTree = userHooks.getKeyByAlias("GetFileTree");
     const keyPathExclusionsByPurl = userHooks.getKeyByAlias(
         "GetPathExclusionsByPurl",
     );
@@ -100,7 +101,7 @@ const ExclusionForm = ({
                         description: "Path exclusion added successfully.",
                     });
                     // When a path exclusion is added, invalidate the corresponding queries to refetch the data
-                    queryClient.invalidateQueries(keyPathExclusionsByPurl);
+                    queryClient.invalidateQueries(keyFileTree);
                     queryClient.invalidateQueries(keyPathExclusionCountByPurl);
                 },
                 onError: (error) => {

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -132,10 +132,7 @@ const PackageInspector = ({ purl, path }: Props) => {
     // Open the nodes that have the filtered license
     const handleOpenFilteredNodes = () => {
         const nodes = findNodesWithLicense(treeData, licenseFilter);
-        // This is a temporary fix for DO-601: don't close all nodes
-        // before opening the nodes with a filtered license, because
-        // the latter doesn't work in all cases
-        //treeRef.current?.closeAll();
+        treeRef.current?.closeAll();
         for (const node of nodes) {
             treeRef.current?.openParents(node.id);
         }

--- a/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
+++ b/apps/clearance_ui/src/components/main_ui/inspector/package_inspector/PackageInspector.tsx
@@ -62,23 +62,16 @@ const PackageInspector = ({ purl, path }: Props) => {
     const router = useRouter();
     const pathPurl = toPathPurl(purl);
 
-    // Fetch the package file tree data
+    // Fetch the package file tree data. Also fetch path exclusion status
+    // with the same query, no need anymore to use a separate query for it.
     const { data, isLoading, error } = userHooks.useGetFileTree(
         {
             withCredentials: true,
             params: {
                 purl: pathPurl,
             },
-        },
-        { enabled: !!pathPurl },
-    );
-
-    // Fetch the path exclusions for the package
-    const { data: pathExclusions } = userHooks.useGetPathExclusionsByPurl(
-        {
-            withCredentials: true,
-            params: {
-                purl: pathPurl,
+            queries: {
+                includeIsExcluded: true,
             },
         },
         { enabled: !!pathPurl },
@@ -155,17 +148,11 @@ const PackageInspector = ({ purl, path }: Props) => {
 
     // Construct the tree data
     useEffect(() => {
-        if (data && pathExclusions) {
-            const convertedData = convertJsonToTree(
-                data.filetrees,
-                pathExclusions.pathExclusions.map(
-                    (exclusion) => exclusion.pattern,
-                ),
-                "",
-            );
+        if (data) {
+            const convertedData = convertJsonToTree(data.filetrees, "");
             setTreeData(convertedData);
         }
-    }, [data, pathExclusions]);
+    }, [data]);
 
     // Handle expanding and collapsing the whole tree
     useEffect(() => {
@@ -278,7 +265,7 @@ const PackageInspector = ({ purl, path }: Props) => {
                         <Loader2 className="mr-2 h-16 w-16 animate-spin" />
                     </div>
                 )}
-                {data && pathExclusions && (
+                {data && (
                     <Tree
                         className=""
                         data={treeData}

--- a/apps/clearance_ui/src/helpers/convertJsonToTree.ts
+++ b/apps/clearance_ui/src/helpers/convertJsonToTree.ts
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 import type { FileTreeType } from "validation-helpers";
-import { isPathExcluded } from "@/helpers/isExcluded";
 import { sortTree } from "@/helpers/sortTree";
 import { updateExclusionStatus } from "@/helpers/updateExclusionStatus";
 import type { TreeNode } from "@/types";
 
 export const convertJsonToTree = (
     filetrees: FileTreeType[],
-    patterns?: string[],
     licenseFilter?: string,
 ): TreeNode[] => {
     let id = 1; // Initialize a unique ID counter
@@ -28,12 +26,6 @@ export const convertJsonToTree = (
 
             fullPath += (i > 0 ? "/" : "") + part;
 
-            // Determine if the current node's path matches any of the provided patterns
-            const isExcluded =
-                patterns?.some((pattern) =>
-                    isPathExcluded(fullPath, pattern),
-                ) || false;
-
             if (!map[fullPath]) {
                 const newNode: TreeNode = {
                     id: id.toString(),
@@ -42,7 +34,7 @@ export const convertJsonToTree = (
                     fileSha256: isLastPart ? fileTree.fileSha256 : undefined,
                     hasLicenseFindings: false,
                     hasLicenseConclusions: false,
-                    isExcluded: isExcluded,
+                    isExcluded: fileTree.isExcluded,
                     selectionStatus: 0, // Initial selection status
                     file: {
                         licenseFindings: isLastPart
@@ -87,9 +79,6 @@ export const convertJsonToTree = (
                     map[fullPath].hasLicenseConclusions = true;
                 }
             }
-
-            // Update isExcluded for existing nodes
-            map[fullPath].isExcluded = isExcluded;
 
             // Propagate the hasLicenseFindings and hasLicenseConclusions flags to ancestor directories
             if (


### PR DESCRIPTION
With some refactoring of the filetree query in backend, the path exclusion status of the nodes in the filetree don't need to be fetched as a separate query and calculated explicitly for the filetree anymore.  This fixes the out-of-sync bug between the filetree component's state with respect to its UI.

Also resolves DO-601, as the root cause for that bug was the same (using two separate queries for the same filetree).