### PR TITLE
Do 658 get file level information about scancode version from backend

### DIFF
--- a/apps/api/src/helpers/db_operations.ts
+++ b/apps/api/src/helpers/db_operations.ts
@@ -547,6 +547,7 @@ export const saveJobResults = async (
                             id: dbFile.id,
                             data: {
                                 scanStatus: "scanned",
+                                scanner: scanner,
                             },
                         });
                     }

--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -1098,16 +1098,16 @@ export const findFileByHash = async (hash: string): Promise<File | null> => {
     return file;
 };
 
-export const findFileSha256ByPurlAndPath = async (
+export const findFileSha256AndScannerByPurlAndPath = async (
     purl: string,
     path: string,
-): Promise<string | null> => {
+): Promise<{ sha256: string; scanner: string } | null> => {
     let retries = initialRetryCount;
-    let fileSha256: string | null = null;
+    let file: { sha256: string; scanner: string } | null = null;
 
     while (retries > 0) {
         try {
-            fileSha256 =
+            file =
                 (
                     await prisma.fileTree.findFirst({
                         where: {
@@ -1120,11 +1120,12 @@ export const findFileSha256ByPurlAndPath = async (
                             file: {
                                 select: {
                                     sha256: true,
+                                    scanner: true,
                                 },
                             },
                         },
                     })
-                )?.file.sha256 || null;
+                )?.file || null;
             break;
         } catch (error) {
             console.log("Error with trying to find File: " + error);
@@ -1135,7 +1136,7 @@ export const findFileSha256ByPurlAndPath = async (
         }
     }
 
-    return fileSha256;
+    return file;
 };
 
 export const findFileHashesByPackageId = async (

--- a/apps/api/src/helpers/temp/db_queries.ts
+++ b/apps/api/src/helpers/temp/db_queries.ts
@@ -1098,16 +1098,16 @@ export const findFileByHash = async (hash: string): Promise<File | null> => {
     return file;
 };
 
-export const findFileSha256ByPurlAndPath = async (
+export const findFileSha256AndScannerByPurlAndPath = async (
     purl: string,
     path: string,
-): Promise<string | null> => {
+): Promise<{ sha256: string; scanner: string } | null> => {
     let retries = initialRetryCount;
-    let fileSha256: string | null = null;
+    let file: { sha256: string; scanner: string } | null = null;
 
     while (retries > 0) {
         try {
-            fileSha256 =
+            file =
                 (
                     await prisma.fileTree.findFirst({
                         where: {
@@ -1120,11 +1120,12 @@ export const findFileSha256ByPurlAndPath = async (
                             file: {
                                 select: {
                                     sha256: true,
+                                    scanner: true,
                                 },
                             },
                         },
                     })
-                )?.file.sha256 || null;
+                )?.file || null;
             break;
         } catch (error) {
             console.log("Error with trying to find File: " + error);
@@ -1135,7 +1136,7 @@ export const findFileSha256ByPurlAndPath = async (
         }
     }
 
-    return fileSha256;
+    return file;
 };
 
 export const findFileHashesByPackageId = async (

--- a/apps/api/src/routes/temp/user_router.ts
+++ b/apps/api/src/routes/temp/user_router.ts
@@ -1726,14 +1726,17 @@ userRouter.get("/packages/:purl/filetrees/:path/files", async (req, res) => {
         const purl = req.params.purl;
         const path = req.params.path;
 
-        const sha256 = await dbQueries.findFileSha256ByPurlAndPath(purl, path);
+        const file = await dbQueries.findFileSha256AndScannerByPurlAndPath(
+            purl,
+            path,
+        );
 
-        if (!sha256) throw new CustomError("File not found", 400);
+        if (!file) throw new CustomError("File not found", 400);
 
         const presignedGetUrl = await getPresignedGetUrl(
             s3Client,
             process.env.SPACES_BUCKET || "doubleopen",
-            sha256,
+            file.sha256,
         );
 
         if (!presignedGetUrl) {
@@ -1744,8 +1747,9 @@ userRouter.get("/packages/:purl/filetrees/:path/files", async (req, res) => {
         }
 
         res.status(200).json({
-            sha256: sha256,
+            sha256: file.sha256,
             downloadUrl: presignedGetUrl,
+            scanner: file.scanner,
         });
     } catch (error) {
         console.log("Error: ", error);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "db:migrate:reset": "npm run build:s3 && dotenv -e .env.local -- turbo run db:migrate:reset",
         "db:push": "turbo run db:push",
         "db:push-accept-data-loss": "prisma db push --schema ./packages/database/prisma/schema.prisma --accept-data-loss",
-        "db:studio": "prisma studio --schema ./packages/database/prisma/schema.prisma",
+        "db:studio": "dotenv -e .env.local -- prisma studio --schema ./packages/database/prisma/schema.prisma",
         "clean": "npm exec --workspaces -- npx rimraf node_modules && npx rimraf package-lock.json && npx rimraf node_modules",
         "clean-build": "npm run clean-dist && turbo run build --no-cache --force",
         "clean-dist": "npm exec --workspaces -- npx rimraf dist",

--- a/packages/database/prisma/migrations/20240402082205_add_scanner_version_to_file_table/migration.sql
+++ b/packages/database/prisma/migrations/20240402082205_add_scanner_version_to_file_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "File" ADD COLUMN     "scanner" TEXT NOT NULL DEFAULT 'scancode-toolkit@32.0.4';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -29,6 +29,7 @@ model File {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
   scanStatus String
+  scanner    String   @default("scancode-toolkit@32.0.4")
 
   filetrees          FileTree[]
   licenseFindings    LicenseFinding[]

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -10301,16 +10301,19 @@ declare const userAPI: [
             {
                 sha256: zod.ZodString;
                 downloadUrl: zod.ZodString;
+                scanner: zod.ZodString;
             },
             "strip",
             zod.ZodTypeAny,
             {
                 sha256: string;
                 downloadUrl: string;
+                scanner: string;
             },
             {
                 sha256: string;
                 downloadUrl: string;
+                scanner: string;
             }
         >;
         errors: [
@@ -17823,16 +17826,19 @@ declare const dosAPI: [
             {
                 sha256: zod.ZodString;
                 downloadUrl: zod.ZodString;
+                scanner: zod.ZodString;
             },
             "strip",
             zod.ZodTypeAny,
             {
                 sha256: string;
                 downloadUrl: string;
+                scanner: string;
             },
             {
                 sha256: string;
                 downloadUrl: string;
+                scanner: string;
             }
         >;
         errors: [

--- a/packages/validation-helpers/src/api/schemas/user_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/user_schemas.ts
@@ -562,6 +562,7 @@ export const PutTokenRes = z.object({
 export const GetFileRes = z.object({
     sha256: z.string(),
     downloadUrl: z.string(),
+    scanner: z.string(),
 });
 
 //------------------ GET license-findings -------------------


### PR DESCRIPTION
This PR adds into the File database table a field "scanner", which contains information about the scanner that was used to scan the file.  Corresponding changes are made to the queries to get this information when opening a file in Clearance UI.