### PR TITLE
Do 381 allow users to edit bulk conclusions in clearance library

### DIFF
--- a/apps/clearance_ui/src/@types/table-core.d.ts
+++ b/apps/clearance_ui/src/@types/table-core.d.ts
@@ -28,5 +28,7 @@ declare module "@tanstack/table-core" {
     interface ColumnMeta<TData extends RowData, TValue> {
         // The type of the column, used to determine the type of the cell
         type?: string;
+        // Option to break the text from any point in the text in the cell.
+        breakAll?: boolean;
     }
 }

--- a/apps/clearance_ui/src/@types/table-core.d.ts
+++ b/apps/clearance_ui/src/@types/table-core.d.ts
@@ -12,8 +12,8 @@ declare module "@tanstack/table-core" {
     interface TableMeta<TData extends RowData> {
         // Keeps track of the rows that are being edited to enable showing
         // the editable cell components.
-        editedRows: { [key: number]: boolean };
-        setEditedRows: React.Dispatch<
+        selectedRowsForEditing: { [key: number]: boolean };
+        setSelectedRowsForEditing: React.Dispatch<
             React.SetStateAction<{ [key: number]: boolean }>
         >;
         // Function used to revert the data of a row to the original data.

--- a/apps/clearance_ui/src/@types/table-core.d.ts
+++ b/apps/clearance_ui/src/@types/table-core.d.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { RowData } from "@tanstack/react-table";
+
+declare module "@tanstack/table-core" {
+    // Meta data for the table and columns that is accessible in the DataTable
+    // component, the columns object and different cell components.
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface TableMeta<TData extends RowData> {
+        // Keeps track of the rows that are being edited to enable showing
+        // the editable cell components.
+        editedRows: { [key: number]: boolean };
+        setEditedRows: React.Dispatch<
+            React.SetStateAction<{ [key: number]: boolean }>
+        >;
+        // Function used to revert the data of a row to the original data.
+        revertData: (rowId: number, revert: boolean) => void;
+        // Function used to update the data of a row.
+        updateData: (rowId: number, columnId: string, value: string) => void;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface ColumnMeta<TData extends RowData, TValue> {
+        // The type of the column, used to determine the type of the cell
+        type?: string;
+    }
+}

--- a/apps/clearance_ui/src/@types/table-core.d.ts
+++ b/apps/clearance_ui/src/@types/table-core.d.ts
@@ -17,9 +17,11 @@ declare module "@tanstack/table-core" {
             React.SetStateAction<{ [key: number]: boolean }>
         >;
         // Function used to revert the data of a row to the original data.
-        revertData: (rowId: number, revert: boolean) => void;
+        revertData: (rowId: number) => void;
         // Function used to update the data of a row.
         updateData: (rowId: number, columnId: string, value: string) => void;
+        // Function used to update persisted changes to the original data
+        updateOriginalData: (rowId: number) => void;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/clearance_ui/src/@types/table-core.d.ts
+++ b/apps/clearance_ui/src/@types/table-core.d.ts
@@ -19,7 +19,11 @@ declare module "@tanstack/table-core" {
         // Function used to revert the data of a row to the original data.
         revertData: (rowId: number) => void;
         // Function used to update the data of a row.
-        updateData: (rowId: number, columnId: string, value: string) => void;
+        updateData: (
+            rowId: number,
+            columnId: string,
+            value: string | boolean,
+        ) => void;
         // Function used to update persisted changes to the original data
         updateOriginalData: (rowId: number) => void;
     }

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/ActionCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/ActionCell.tsx
@@ -4,34 +4,84 @@
 
 import { CellContext } from "@tanstack/react-table";
 import { ZodiosResponseByAlias } from "@zodios/core";
+import { Check, X } from "lucide-react";
 import { userAPI } from "validation-helpers";
 import { useUser } from "@/hooks/useUser";
+import { Button } from "@/components/ui/button";
 import DeleteBulkConclusion from "@/components/common/delete_item/DeleteBulkConclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
 
 type BulkConclusion = ZodiosResponseByAlias<
     typeof userAPI,
     "GetBulkConclusions"
->["bulkConclusions"][0];
+>["bulkConclusions"][number];
 
-const ActionCell = ({ row }: CellContext<BulkConclusion, unknown>) => {
+const ActionCell = ({ row, table }: CellContext<BulkConclusion, unknown>) => {
     // Get user role, to decide what rights the user has for this view
     const user = useUser();
-    return user ? (
+
+    const meta = table.options.meta;
+
+    const handleCancel = () => {
+        meta?.revertData(row.index);
+        meta?.setSelectedRowsForEditing(() => {
+            const old = meta.selectedRowsForEditing;
+            return {
+                ...old,
+                [parseInt(row.id)]: false,
+            };
+        });
+    };
+
+    const handleSave = () => {
+        console.log("save");
+    };
+
+    const handleEdit = () => {
+        meta?.setSelectedRowsForEditing(() => {
+            const old = meta.selectedRowsForEditing;
+            return {
+                ...old,
+                [parseInt(row.id)]: true,
+            };
+        });
+    };
+
+    return meta?.selectedRowsForEditing[parseInt(row.id)] ? (
+        <div className="flex">
+            <Button
+                onClick={handleSave}
+                name="save"
+                variant="outline"
+                className="mr-1 px-2"
+            >
+                <Check size={16} className="text-green-400" />
+            </Button>
+            <Button
+                onClick={handleCancel}
+                name="cancel"
+                variant="outline"
+                className="mr-1 px-2"
+            >
+                <X size={16} className="text-[#ff3366]" />
+            </Button>
+        </div>
+    ) : (
         <>
-            {(user.role === "ADMIN" ||
-                user.username === row.original.user.username) && (
-                <div className="flex items-center">
-                    <EditButton
-                        onClick={() => {}}
-                        name="edit"
-                        className="mr-1 px-2"
-                    />
-                    <DeleteBulkConclusion id={row.original.id} />
-                </div>
-            )}
+            {user &&
+                (user.role === "ADMIN" ||
+                    user.username === row.original.user.username) && (
+                    <div className="flex items-center">
+                        <EditButton
+                            onClick={handleEdit}
+                            name="edit"
+                            className="mr-1 px-2"
+                        />
+                        <DeleteBulkConclusion id={row.original.id} />
+                    </div>
+                )}
         </>
-    ) : null;
+    );
 };
 
 export default ActionCell;

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/ActionCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/ActionCell.tsx
@@ -2,25 +2,78 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { useQueryClient } from "@tanstack/react-query";
 import { CellContext } from "@tanstack/react-table";
-import { ZodiosResponseByAlias } from "@zodios/core";
-import { Check, X } from "lucide-react";
+import { ZodiosBodyByAlias, ZodiosResponseByAlias } from "@zodios/core";
+import { isAxiosError } from "axios";
+import { Check, Loader2, X } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { userAPI } from "validation-helpers";
 import { useUser } from "@/hooks/useUser";
+import { userHooks } from "@/hooks/zodiosHooks";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
 import DeleteBulkConclusion from "@/components/common/delete_item/DeleteBulkConclusion";
 import EditButton from "@/components/common/edit_item/EditButton";
+import { isValidConcludedExpression } from "@/helpers/isValidConcludedExpression";
 
 type BulkConclusion = ZodiosResponseByAlias<
     typeof userAPI,
     "GetBulkConclusions"
 >["bulkConclusions"][number];
 
+type BulkConclusionUpdateData = ZodiosBodyByAlias<
+    typeof userAPI,
+    "PutBulkConclusion"
+>;
+
 const ActionCell = ({ row, table }: CellContext<BulkConclusion, unknown>) => {
     // Get user role, to decide what rights the user has for this view
     const user = useUser();
-
+    const session = useSession();
+    const bcKey = userHooks.getKeyByAlias("GetBulkConclusions");
+    const queryClient = useQueryClient();
     const meta = table.options.meta;
+
+    const { mutate: UpdateBulkConclusion, isLoading } =
+        userHooks.usePutBulkConclusion(
+            {
+                headers: {
+                    Authorization: `Bearer ${session.data?.accessToken}`,
+                },
+                params: {
+                    id: row.original.id,
+                },
+            },
+            {
+                onSuccess: () => {
+                    meta?.setSelectedRowsForEditing(() => {
+                        const old = meta.selectedRowsForEditing;
+                        return {
+                            ...old,
+                            [parseInt(row.id)]: false,
+                        };
+                    });
+                    meta?.updateOriginalData(row.index);
+                    queryClient.invalidateQueries(bcKey);
+                    toast({
+                        title: "Bulk conclusion updated",
+                        description: "Bulk conclusion updated successfully",
+                    });
+                },
+                onError: (error) => {
+                    const msg = isAxiosError(error)
+                        ? error.response?.data.message
+                        : error.message;
+
+                    toast({
+                        variant: "destructive",
+                        title: "Error",
+                        description: msg,
+                    });
+                },
+            },
+        );
 
     const handleCancel = () => {
         meta?.revertData(row.index);
@@ -34,7 +87,32 @@ const ActionCell = ({ row, table }: CellContext<BulkConclusion, unknown>) => {
     };
 
     const handleSave = () => {
-        console.log("save");
+        const isValidObj = isValidConcludedExpression(
+            row.getValue("concludedLicenseExpressionSPDX"),
+        );
+
+        if (isValidObj.isValid) {
+            const body: BulkConclusionUpdateData = {
+                pattern: row.getValue("pattern"),
+                concludedLicenseExpressionSPDX: row.getValue(
+                    "concludedLicenseExpressionSPDX",
+                ),
+                comment: row.getValue("comment"),
+                local: row.getValue("local"),
+            };
+
+            UpdateBulkConclusion(body);
+        } else {
+            let description = "Invalid concluded license expression";
+            if (isValidObj.errWord !== null) {
+                description += ": syntax error in '" + isValidObj.errWord + "'";
+            }
+            toast({
+                variant: "destructive",
+                title: "Error",
+                description: description,
+            });
+        }
     };
 
     const handleEdit = () => {
@@ -55,7 +133,11 @@ const ActionCell = ({ row, table }: CellContext<BulkConclusion, unknown>) => {
                 variant="outline"
                 className="mr-1 px-2"
             >
-                <Check size={16} className="text-green-400" />
+                {isLoading ? (
+                    <Loader2 size={16} className="animate-spin" />
+                ) : (
+                    <Check size={16} className="text-green-400" />
+                )}
             </Button>
             <Button
                 onClick={handleCancel}
@@ -72,11 +154,15 @@ const ActionCell = ({ row, table }: CellContext<BulkConclusion, unknown>) => {
                 (user.role === "ADMIN" ||
                     user.username === row.original.user.username) && (
                     <div className="flex items-center">
-                        <EditButton
-                            onClick={handleEdit}
-                            name="edit"
-                            className="mr-1 px-2"
-                        />
+                        {isLoading ? (
+                            <Loader2 size={20} className="mx-2 animate-spin" />
+                        ) : (
+                            <EditButton
+                                onClick={handleEdit}
+                                name="edit"
+                                className="mr-1 px-2"
+                            />
+                        )}
                         <DeleteBulkConclusion id={row.original.id} />
                     </div>
                 )}

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/ActionCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/ActionCell.tsx
@@ -7,6 +7,7 @@ import { ZodiosResponseByAlias } from "@zodios/core";
 import { userAPI } from "validation-helpers";
 import { useUser } from "@/hooks/useUser";
 import DeleteBulkConclusion from "@/components/common/delete_item/DeleteBulkConclusion";
+import EditButton from "@/components/common/edit_item/EditButton";
 
 type BulkConclusion = ZodiosResponseByAlias<
     typeof userAPI,
@@ -20,7 +21,14 @@ const ActionCell = ({ row }: CellContext<BulkConclusion, unknown>) => {
         <>
             {(user.role === "ADMIN" ||
                 user.username === row.original.user.username) && (
-                <DeleteBulkConclusion id={row.original.id} />
+                <div className="flex items-center">
+                    <EditButton
+                        onClick={() => {}}
+                        name="edit"
+                        className="mr-1 px-2"
+                    />
+                    <DeleteBulkConclusion id={row.original.id} />
+                </div>
             )}
         </>
     ) : null;

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/DataTable.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/DataTable.tsx
@@ -30,9 +30,12 @@ interface DataTableProps<TData, TValue> {
 
 export function DataTable<TData, TValue>({
     columns,
-    data,
+    data: initialData,
     pageCount,
 }: DataTableProps<TData, TValue>) {
+    const [data, setData] = useState(initialData);
+    const [originalData, setOriginalData] = useState(initialData);
+    const [selectedRowsForEditing, setSelectedRowsForEditing] = useState({});
     const [searchPurl, setSearchPurl] = useQueryState(
         "searchPurl",
         parseAsString,
@@ -56,6 +59,37 @@ export function DataTable<TData, TValue>({
         pageCount: pageCount,
         getCoreRowModel: getCoreRowModel(),
         manualPagination: true,
+        meta: {
+            selectedRowsForEditing,
+            setSelectedRowsForEditing,
+            revertData: (rowId: number) => {
+                setData((old) =>
+                    old.map((row, index) =>
+                        index === rowId ? originalData[rowId] : row,
+                    ),
+                );
+            },
+            updateData: (rowId: number, columnId: string, value: string) => {
+                setData((old) =>
+                    old.map((row, index) => {
+                        if (index === rowId) {
+                            return {
+                                ...old[rowId]!,
+                                [columnId]: value,
+                            };
+                        }
+                        return row;
+                    }),
+                );
+            },
+            updateOriginalData: (rowId: number) => {
+                setOriginalData((old) =>
+                    old.map((row, index) =>
+                        index === rowId ? data[rowId] : row,
+                    ),
+                );
+            },
+        },
     });
 
     return (

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/DataTable.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/DataTable.tsx
@@ -69,7 +69,11 @@ export function DataTable<TData, TValue>({
                     ),
                 );
             },
-            updateData: (rowId: number, columnId: string, value: string) => {
+            updateData: (
+                rowId: number,
+                columnId: string,
+                value: string | boolean,
+            ) => {
                 setData((old) =>
                     old.map((row, index) => {
                         if (index === rowId) {

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/TableCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/TableCell.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useState } from "react";
+import { CellContext } from "@tanstack/react-table";
+import { ZodiosResponseByAlias } from "@zodios/core";
+import { userAPI } from "validation-helpers";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+type BulkConclusion = ZodiosResponseByAlias<
+    typeof userAPI,
+    "GetBulkConclusions"
+>["bulkConclusions"][number];
+
+const TableCell = ({
+    getValue,
+    row,
+    column,
+    table,
+}: CellContext<BulkConclusion, unknown>) => {
+    const initialValue = getValue();
+    const columnMeta = column.columnDef.meta;
+    const tableMeta = table.options.meta;
+    const [value, setValue] = useState(
+        typeof initialValue === "string" ? initialValue : "",
+    );
+
+    useEffect(() => {
+        setValue(typeof initialValue === "string" ? initialValue : "");
+    }, [initialValue]);
+
+    const onBlur = () => {
+        tableMeta?.updateData(row.index, column.id, value);
+    };
+
+    if (tableMeta?.selectedRowsForEditing[parseInt(row.id)]) {
+        return columnMeta?.type === "textarea" ? (
+            <Textarea
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onBlur={onBlur}
+                name={column.id}
+                aria-label={column.id}
+            />
+        ) : (
+            <Input
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onBlur={onBlur}
+                type={"text"}
+                name={column.id}
+                aria-label={column.id}
+            />
+        );
+    }
+    return <span>{value}</span>;
+};
+
+export default TableCell;

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/TableCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/TableCell.tsx
@@ -55,7 +55,11 @@ const TableCell = ({
             />
         );
     }
-    return <span>{value}</span>;
+    return (
+        <span className={columnMeta?.breakAll ? "break-all" : undefined}>
+            {value}
+        </span>
+    );
 };
 
 export default TableCell;

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/TableCellBoolean.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/TableCellBoolean.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useState } from "react";
+import { CellContext } from "@tanstack/react-table";
+import { ZodiosResponseByAlias } from "@zodios/core";
+import { userAPI } from "validation-helpers";
+import { Checkbox } from "@/components/ui/checkbox";
+
+type BulkConclusion = ZodiosResponseByAlias<
+    typeof userAPI,
+    "GetBulkConclusions"
+>["bulkConclusions"][0];
+
+const TableCellBoolean = ({
+    getValue,
+    row,
+    column,
+    table,
+}: CellContext<BulkConclusion, unknown>) => {
+    const initialValue = getValue();
+    const tableMeta = table.options.meta;
+    const [value, setValue] = useState(
+        typeof initialValue === "boolean" ? initialValue : false,
+    );
+
+    useEffect(() => {
+        setValue(typeof initialValue === "boolean" ? initialValue : false);
+    }, [initialValue]);
+
+    const onBlur = () => {
+        tableMeta?.updateData(row.index, column.id, value);
+    };
+
+    if (tableMeta?.selectedRowsForEditing[parseInt(row.id)]) {
+        return (
+            <Checkbox
+                checked={value}
+                onCheckedChange={(newValue) => {
+                    setValue(newValue.valueOf() as boolean);
+                }}
+                onBlur={onBlur}
+                name={column.id}
+                aria-label={column.id}
+            />
+        );
+    }
+
+    return <span>{value ? "Yes" : "No"}</span>;
+};
+
+export default TableCellBoolean;

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
@@ -296,6 +296,7 @@ export const columns = (
             cell: TableCell,
             meta: {
                 type: "textarea",
+                breakAll: true,
             },
         },
         {

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
@@ -24,6 +24,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import ActionCell from "@/components/clearance_library/bulk_conclusions/ActionCell";
+import TableCell from "@/components/clearance_library/bulk_conclusions/TableCell";
 import BCAffectedFilesTooltip from "@/components/common/BCAffectedFilesTooltip";
 import PurlDetails from "@/components/common/PurlDetails";
 
@@ -32,7 +33,7 @@ import PurlDetails from "@/components/common/PurlDetails";
 export type BulkConclusion = ZodiosResponseByAlias<
     typeof userAPI,
     "GetBulkConclusions"
->["bulkConclusions"][0];
+>["bulkConclusions"][number];
 
 export const columns = (
     sortBy: string | null,
@@ -292,9 +293,10 @@ export const columns = (
                     </Button>
                 );
             },
-            cell: ({ row }) => (
-                <div className="break-all">{row.original.pattern}</div>
-            ),
+            cell: TableCell,
+            meta: {
+                type: "textarea",
+            },
         },
         {
             accessorKey: "licenseExpressionSPDX",
@@ -405,6 +407,10 @@ export const columns = (
                             </Button>
                         );
                     },
+                    cell: TableCell,
+                    meta: {
+                        type: "text",
+                    },
                 },
             ],
         },
@@ -497,6 +503,10 @@ export const columns = (
                         )}
                     </Button>
                 );
+            },
+            cell: TableCell,
+            meta: {
+                type: "textarea",
             },
         },
         {

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
@@ -433,7 +433,22 @@ export const columns = (
                             </Label>
                         );
                     },
-                    cell: ({ row }) => {
+                    cell: ({ row, table }) => {
+                        const selectedRowsForEditing =
+                            table.options.meta?.selectedRowsForEditing;
+
+                        if (
+                            selectedRowsForEditing &&
+                            Object.keys(selectedRowsForEditing).length > 0
+                        ) {
+                            for (const key in selectedRowsForEditing) {
+                                if (selectedRowsForEditing[key] !== false) {
+                                    // If any row is in edit mode, don't show the tooltip
+                                    // as for some reason, it causes a lag in the input fields
+                                    return null;
+                                }
+                            }
+                        }
                         return (
                             <BCAffectedFilesTooltip
                                 bulkConclusionId={row.original.id}
@@ -452,7 +467,22 @@ export const columns = (
                             </Label>
                         );
                     },
-                    cell: ({ row }) => {
+                    cell: ({ row, table }) => {
+                        const selectedRowsForEditing =
+                            table.options.meta?.selectedRowsForEditing;
+
+                        if (
+                            selectedRowsForEditing &&
+                            Object.keys(selectedRowsForEditing).length > 0
+                        ) {
+                            for (const key in selectedRowsForEditing) {
+                                if (selectedRowsForEditing[key] !== false) {
+                                    // If any row is in edit mode, don't show the tooltip
+                                    // as for some reason, it causes a lag in the input fields
+                                    return null;
+                                }
+                            }
+                        }
                         return (
                             <BCAffectedFilesTooltip
                                 bulkConclusionId={row.original.id}

--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/columns.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/tooltip";
 import ActionCell from "@/components/clearance_library/bulk_conclusions/ActionCell";
 import TableCell from "@/components/clearance_library/bulk_conclusions/TableCell";
+import TableCellBoolean from "@/components/clearance_library/bulk_conclusions/TableCellBoolean";
 import BCAffectedFilesTooltip from "@/components/common/BCAffectedFilesTooltip";
 import PurlDetails from "@/components/common/PurlDetails";
 
@@ -509,6 +510,13 @@ export const columns = (
             meta: {
                 type: "textarea",
             },
+        },
+        {
+            accessorKey: "local",
+            header: () => (
+                <Label className="cursor-pointer font-bold">Local</Label>
+            ),
+            cell: TableCellBoolean,
         },
         {
             id: "actions",

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/ActionCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/ActionCell.tsx
@@ -69,8 +69,8 @@ const ActionCell = ({
     const setEditedRows = (e: React.MouseEvent<HTMLButtonElement>) => {
         const elName = e.currentTarget.name;
         if (e.currentTarget.name !== "save") {
-            meta?.setEditedRows(() => {
-                const old = meta.editedRows;
+            meta?.setSelectedRowsForEditing(() => {
+                const old = meta.selectedRowsForEditing;
                 return {
                     ...old,
                     [parseInt(row.id)]: !old[parseInt(row.id)],
@@ -85,8 +85,8 @@ const ActionCell = ({
                     row.getValue("concludedLicenseExpressionSPDX"),
                 );
                 if (isValidObj.isValid) {
-                    meta?.setEditedRows(() => {
-                        const old = meta.editedRows;
+                    meta?.setSelectedRowsForEditing(() => {
+                        const old = meta.selectedRowsForEditing;
                         return {
                             ...old,
                             [parseInt(row.id)]: !old[parseInt(row.id)],
@@ -114,7 +114,7 @@ const ActionCell = ({
         }
     };
 
-    return meta?.editedRows[parseInt(row.id)] ? (
+    return meta?.selectedRowsForEditing[parseInt(row.id)] ? (
         <div className="flex">
             <TooltipProvider>
                 <Tooltip>

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
@@ -7,7 +7,6 @@ import {
     ColumnDef,
     flexRender,
     getCoreRowModel,
-    RowData,
     useReactTable,
 } from "@tanstack/react-table";
 import debounce from "lodash.debounce";
@@ -27,23 +26,6 @@ interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
     data: TData[];
     pageCount: number;
-}
-
-declare module "@tanstack/table-core" {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface TableMeta<TData extends RowData> {
-        editedRows: { [key: number]: boolean };
-        setEditedRows: React.Dispatch<
-            React.SetStateAction<{ [key: number]: boolean }>
-        >;
-        revertData: (rowId: number, revert: boolean) => void;
-        updateData: (rowId: number, columnId: string, value: string) => void;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface ColumnMeta<TData extends RowData, TValue> {
-        type?: string;
-    }
 }
 
 export function DataTable<TData, TValue>({

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
@@ -75,7 +75,11 @@ export function DataTable<TData, TValue>({
                     ),
                 );
             },
-            updateData: (rowId: number, columnId: string, value: string) => {
+            updateData: (
+                rowId: number,
+                columnId: string,
+                value: string | boolean,
+            ) => {
                 setData((old) =>
                     old.map((row, index) => {
                         if (index === rowId) {

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
@@ -34,7 +34,7 @@ export function DataTable<TData, TValue>({
     pageCount,
 }: DataTableProps<TData, TValue>) {
     const [data, setData] = useState(initialData);
-    const [editedRows, setEditedRows] = useState({});
+    const [selectedRowsForEditing, setSelectedRowsForEditing] = useState({});
 
     const [contextPurl, setContextPurl] = useQueryState(
         "contextPurl",
@@ -64,8 +64,8 @@ export function DataTable<TData, TValue>({
         getCoreRowModel: getCoreRowModel(),
         manualPagination: true,
         meta: {
-            editedRows,
-            setEditedRows,
+            selectedRowsForEditing,
+            setSelectedRowsForEditing,
             revertData: (rowId: number, revert: boolean) => {
                 if (revert) {
                     setData((old) =>

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/DataTable.tsx
@@ -34,6 +34,7 @@ export function DataTable<TData, TValue>({
     pageCount,
 }: DataTableProps<TData, TValue>) {
     const [data, setData] = useState(initialData);
+    const [originalData, setOriginalData] = useState(initialData);
     const [selectedRowsForEditing, setSelectedRowsForEditing] = useState({});
 
     const [contextPurl, setContextPurl] = useQueryState(
@@ -55,6 +56,7 @@ export function DataTable<TData, TValue>({
 
     useEffect(() => {
         setData(initialData);
+        setOriginalData(initialData);
     }, [initialData]);
 
     const table = useReactTable({
@@ -66,20 +68,12 @@ export function DataTable<TData, TValue>({
         meta: {
             selectedRowsForEditing,
             setSelectedRowsForEditing,
-            revertData: (rowId: number, revert: boolean) => {
-                if (revert) {
-                    setData((old) =>
-                        old.map((row, index) =>
-                            index === rowId ? initialData[rowId] : row,
-                        ),
-                    );
-                } else {
-                    setData((old) =>
-                        old.map((row, index) =>
-                            index === rowId ? data[rowId] : row,
-                        ),
-                    );
-                }
+            revertData: (rowId: number) => {
+                setData((old) =>
+                    old.map((row, index) =>
+                        index === rowId ? originalData[rowId] : row,
+                    ),
+                );
             },
             updateData: (rowId: number, columnId: string, value: string) => {
                 setData((old) =>
@@ -92,6 +86,13 @@ export function DataTable<TData, TValue>({
                         }
                         return row;
                     }),
+                );
+            },
+            updateOriginalData: (rowId: number) => {
+                setOriginalData((old) =>
+                    old.map((row, index) =>
+                        index === rowId ? data[rowId] : row,
+                    ),
                 );
             },
         },

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/TableCell.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/TableCell.tsx
@@ -35,7 +35,7 @@ const TableCell = ({
         tableMeta?.updateData(row.index, column.id, value);
     };
 
-    if (tableMeta?.editedRows[parseInt(row.id)]) {
+    if (tableMeta?.selectedRowsForEditing[parseInt(row.id)]) {
         return columnMeta?.type === "textarea" ? (
             <Textarea
                 value={value}


### PR DESCRIPTION
This PR adds editing functionality for the bulk conclusions table in Clearance Library. Something to note is that for some reason, when the affected files tooltips are rendered, there is lagging in the performance of the input fields, so the affected files are now set to return null if any field is being edited. There is also a lag when clicking the edit button, it seems to wait until all of the affected files queries of all rows have completed until the inputs for the row in question are shown. So possibly this lagging needs some debugging and refactoring, but this should perhaps be done in a separate PR.