### PR TITLE
Do 687 set scannerjob state to failed if it is in processing state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,9 @@ PORT= # default 5000
 # Allowed origins for CORS
 ALLOWED_ORIGINS= # default http://localhost:3000
 
+# Log level
+LOG_LEVEL= # default info, options: trace/debug/info/warn/error/silent (although note that this hasn't been taken into use everywhere yet, so the log level might be higher than what you set here)
+
 # Database query concurrency and query retry count and interval
 DB_CONCURRENCY= # default 10
 DB_RETRIES= # default 5

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
         "is-valid-path": "^0.1.1",
         "keycloak-connect": "^24.0.3",
         "minimatch": "9.0.4",
+        "loglevel": "1.9.1",
         "node-cache": "5.1.2",
         "node-cron": "3.0.3",
         "packageurl-js": "1.2.1",

--- a/apps/api/src/helpers/db_operations.ts
+++ b/apps/api/src/helpers/db_operations.ts
@@ -336,7 +336,8 @@ export const saveJobResults = async (
                         );
 
                         if (!dbFile) {
-                            dbFile = await dbQueries.createFile({
+                            // Use createFileIfNotExists to prevent issue when a parallel task creates the same file
+                            dbFile = await dbQueries.createFileIfNotExists({
                                 sha256: file.sha256,
                                 scanStatus: "notStarted",
                             });

--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -904,6 +904,36 @@ export const updateBulkConclusionPackageId = async (
     return bulkConclusion;
 };
 
+export const updateSystemIssue = async (
+    id: number,
+    updateData: Prisma.SystemIssueUpdateInput,
+): Promise<SystemIssue> => {
+    let retries = initialRetryCount;
+    let systemIssue: SystemIssue | null = null;
+
+    while (retries > 0) {
+        try {
+            systemIssue = await prisma.systemIssue.update({
+                where: {
+                    id: id,
+                },
+                data: updateData,
+            });
+            break;
+        } catch (error) {
+            console.log("Error with trying to update SystemIssue: " + error);
+            handleError(error);
+            retries--;
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    if (!systemIssue) throw new Error("Error: Unable to update SystemIssue");
+
+    return systemIssue;
+};
+
 // ------------------------------- Find -------------------------------
 
 export const findFileByHash = async (hash: string): Promise<File | null> => {
@@ -1435,6 +1465,53 @@ export const findScannerJobsByPackageId = async (
             scannerJobs = await prisma.scannerJob.findMany({
                 where: {
                     packageId: packageId,
+                },
+            });
+            break;
+        } catch (error) {
+            console.log("Error with trying to find ScannerJobs: " + error);
+            handleError(error);
+            retries--;
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    return scannerJobs;
+};
+
+export const findScannerJobsByState = async (
+    state: string,
+): Promise<{
+    id: string;
+    package: {
+        id: number;
+        purl: string;
+    };
+}[]> => {
+    let retries = initialRetryCount;
+    let scannerJobs: {
+        id: string;
+        package: {
+            id: number;
+            purl: string;
+        };
+    }[] = [];
+
+    while (retries > 0) {
+        try {
+            scannerJobs = await prisma.scannerJob.findMany({
+                where: {
+                    state: state,
+                },
+                select: {
+                    id: true,
+                    package: {
+                        select: {
+                            id: true,
+                            purl: true,
+                        },
+                    },
                 },
             });
             break;
@@ -3335,6 +3412,34 @@ export const findLicenseConclusionsByFileSha256 = async (
         }
     }
     return licenseConclusions;
+};
+
+export const findSystemIssues = async (
+    errorCode: string,
+    message: string,
+): Promise<SystemIssue[]> => {
+    let retries = initialRetryCount;
+    let systemIssues: SystemIssue[] = [];
+
+    while (retries > 0) {
+        try {
+            systemIssues = await prisma.systemIssue.findMany({
+                where: {
+                    errorCode: errorCode,
+                    message: message,
+                },
+            });
+            break;
+        } catch (error) {
+            console.log("Error with trying to find SystemIssues: " + error);
+            handleError(error);
+            retries--;
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    return systemIssues;
 };
 
 // ------------------------------ Delete ------------------------------

--- a/apps/api/src/helpers/new_job_process.ts
+++ b/apps/api/src/helpers/new_job_process.ts
@@ -2,12 +2,18 @@
 //
 // SPDX-License-Identifier: MIT
 
+import log from "loglevel";
 import { saveFilesWithHashKey } from "s3-helpers";
 import { findFilesToBeScanned } from "./db_operations";
 import * as dbQueries from "./db_queries";
 import * as fileHelpers from "./file_helpers";
 import { s3Client } from "./s3client";
 import { sendJobToQueue } from "./sa_queries";
+
+const logLevel: log.LogLevelDesc =
+    (process.env.LOG_LEVEL as log.LogLevelDesc) || "info"; // trace/debug/info/warn/error/silent
+
+log.setLevel(logLevel);
 
 export const processPackageAndSendToScanner = async (
     zipFileKey: string,
@@ -17,16 +23,19 @@ export const processPackageAndSendToScanner = async (
     jobStateMap: Map<string, string>,
 ) => {
     try {
-        console.log(
+        log.info(
             scannerJobId + ": Processing files for purl(s) " + purls.join(", "),
         );
 
+        log.debug(scannerJobId + ": Search for main Scanner Job");
         const mainScannerJob = await dbQueries.findScannerJobById(scannerJobId);
 
         if (!mainScannerJob) throw new Error("ScannerJob not found");
 
+        // Create ScannerJobs for each package
         const scannerJobIds: string[] = [scannerJobId];
         if (packageIds.length > 1) {
+            log.debug(scannerJobId + ": Creating ScannerJobs for each package");
             for (const packageId of packageIds) {
                 if (packageId !== mainScannerJob.packageId) {
                     const createdScannerJob = await dbQueries.createScannerJob({
@@ -39,70 +48,102 @@ export const processPackageAndSendToScanner = async (
             }
         }
         // Update Package scanStatuses to 'pending'
+        log.debug(
+            scannerJobId + ": Updating Package scanStatuses to 'pending'",
+        );
         await dbQueries.updateManyPackagesScanStatuses(packageIds, "pending");
         // Update ScannerJob statuses to 'processing'
+        log.debug(
+            scannerJobId + ": Updating ScannerJob statuses to 'processing'",
+        );
         await dbQueries.updateManyScannerJobStates(scannerJobIds, "processing");
         // Downloading zip file from object storage
         const downloadPath = "/tmp/downloads/" + zipFileKey;
+        log.info(scannerJobId + ": Downloading zip file from object storage");
         const downloaded = await fileHelpers.downloadZipFile(
             zipFileKey,
             downloadPath,
         );
 
         if (!downloaded) {
+            log.debug(
+                scannerJobId +
+                    ': Changing Package(s) scanStatus(es) to "failed"',
+            );
             dbQueries.updateManyPackagesScanStatuses(packageIds, "failed");
+            log.debug(
+                scannerJobId + ': Changing ScannerJob(s) state(s) to "failed"',
+            );
             dbQueries.updateManyScannerJobStates(scannerJobIds, "failed");
             throw new Error("Zip file download failed");
         }
 
-        //console.log(scannerJobId + ': Zip file downloaded');
+        log.debug(scannerJobId + ": Zip file downloaded");
 
         // Unzipping the file locally
         const fileNameNoExt = zipFileKey.split(".")[0];
         const basePath = "/tmp/extracted/";
         const extractPath = basePath + fileNameNoExt + "/";
 
+        log.debug(scannerJobId + ": Unzipping the file locally");
         const fileUnzipped = await fileHelpers.unzipFile(
             downloadPath,
             extractPath,
         );
 
         if (!fileUnzipped) {
+            log.debug(
+                scannerJobId +
+                    ': Changing Package(s) scanStatus(es) to "failed"',
+            );
             dbQueries.updateManyPackagesScanStatuses(packageIds, "failed");
+            log.debug(
+                scannerJobId + ': Changing ScannerJob(s) state(s) to "failed"',
+            );
             dbQueries.updateManyScannerJobStates(scannerJobIds, "failed");
             throw new Error("Zip file unzipping failed");
         }
 
-        //console.log(scannerJobId + ': Zip file unzipped');
+        log.debug(scannerJobId + ": Zip file unzipped");
 
         // Saving files in extracted folder to object storage
 
         // Mapping file hashes and the corresponding paths in an array
+        log.debug(scannerJobId + ": Mapping file hashes and paths");
         const fileHashesMappedToPaths: {
             filesCount: number;
             fileHashesAndPaths: Map<string, string[]>;
         } = await fileHelpers.getFileHashesMappedToPaths(extractPath);
 
-        console.log(
+        log.info(
             scannerJobId +
                 ": Found files: " +
                 fileHashesMappedToPaths.filesCount,
         );
-        //console.log(scannerJobId + ': Found unique files: ' + fileHashesMappedToPaths.fileHashesAndPaths.size);
+        log.debug(
+            scannerJobId +
+                ": Found unique files: " +
+                fileHashesMappedToPaths.fileHashesAndPaths.size,
+        );
 
         // Save FileTrees to existing Files (and for files with multiple paths) and get array of files to be scanned
+        log.debug(scannerJobId + ": Finding files to be scanned");
         let filesToBeScanned: { hash: string; path: string }[] | null =
             await findFilesToBeScanned(
                 packageIds,
                 fileHashesMappedToPaths.fileHashesAndPaths,
             );
-        console.log(
+        log.info(
             scannerJobId + ": Uploading and sending to be scanned: ",
             filesToBeScanned.length,
         );
 
         // Uploading files to object storage with the file hash as the key
         if (filesToBeScanned.length > 0) {
+            log.debug(
+                scannerJobId +
+                    ": Uploading files to object storage with the file hash as the key",
+            );
             const uploadedWithHash = await saveFilesWithHashKey(
                 s3Client,
                 process.env.SPACES_BUCKET || "doubleopen",
@@ -113,7 +154,18 @@ export const processPackageAndSendToScanner = async (
             );
 
             if (!uploadedWithHash) {
+                log.debug(
+                    scannerJobId + ": Uploading files to object storage failed",
+                );
+                log.debug(
+                    scannerJobId +
+                        ': Changing Package(s) scanStatus(es) to "failed"',
+                );
                 dbQueries.updateManyPackagesScanStatuses(packageIds, "failed");
+                log.debug(
+                    scannerJobId +
+                        ': Changing ScannerJob(s) state(s) to "failed"',
+                );
                 dbQueries.updateManyScannerJobStates(scannerJobIds, "failed");
                 throw new Error(
                     "Error: Uploading files to object storage failed",
@@ -122,14 +174,14 @@ export const processPackageAndSendToScanner = async (
         }
         jobStateMap.delete(scannerJobId);
 
-        //console.log('Files uploaded to object storage');
+        log.debug(scannerJobId + ": Files uploaded to object storage");
 
         // Deleting local files
         fileHelpers.deleteLocalFiles(downloadPath, extractPath);
-        //console.log('Local files deleted');
+        log.debug(scannerJobId + ": Local files deleted");
 
         if (filesToBeScanned.length > 0) {
-            console.log(
+            log.info(
                 scannerJobId +
                     ": Sending a request to Scanner Agent to add new job to the work queue",
             );
@@ -141,7 +193,7 @@ export const processPackageAndSendToScanner = async (
             );
 
             if (addedToQueue) {
-                console.log(
+                log.info(
                     scannerJobId + ': Updating ScannerJob state to "queued"',
                 );
 
@@ -159,24 +211,30 @@ export const processPackageAndSendToScanner = async (
                 throw new Error("Error: Adding to queue was unsuccessful.");
             }
         } else {
+            log.debug(scannerJobId + ": No files to be scanned");
+            log.debug(
+                scannerJobId + ': Changing Package scanStatus to "scanned"',
+            );
             dbQueries.updateManyPackagesScanStatuses(packageIds, "scanned");
+            log.debug(
+                scannerJobId + ': Changing ScannerJob state to "completed"',
+            );
             dbQueries.updateManyScannerJobStates(scannerJobIds, "completed");
         }
         fileHashesMappedToPaths.fileHashesAndPaths.clear();
         filesToBeScanned = null;
+        log.debug(scannerJobId + ": Processing phase completed");
     } catch (error) {
-        console.log(error);
+        log.error(error);
         try {
-            console.log(
-                scannerJobId + ': Changing ScannerJob state to "failed"',
-            );
+            log.info(scannerJobId + ': Changing ScannerJob state to "failed"');
             dbQueries.updateScannerJob(scannerJobId, { state: "failed" });
-            console.log(
+            log.info(
                 scannerJobId + ': Changing Package scanStatus to "failed"',
             );
             dbQueries.updateManyPackagesScanStatuses(packageIds, "failed");
         } catch (error) {
-            console.log(
+            log.error(
                 scannerJobId +
                     ': Unable to update ScannerJob and Package statuses to "failed"',
             );

--- a/apps/api/src/helpers/new_job_process.ts
+++ b/apps/api/src/helpers/new_job_process.ts
@@ -74,7 +74,11 @@ export const processPackageAndSendToScanner = async (
             log.debug(
                 scannerJobId + ': Changing ScannerJob(s) state(s) to "failed"',
             );
-            dbQueries.updateManyScannerJobStates(scannerJobIds, "failed");
+            dbQueries.updateManyScannerJobStates(
+                scannerJobIds,
+                "failed",
+                "processing",
+            );
             throw new Error("Zip file download failed");
         }
 
@@ -100,7 +104,11 @@ export const processPackageAndSendToScanner = async (
             log.debug(
                 scannerJobId + ': Changing ScannerJob(s) state(s) to "failed"',
             );
-            dbQueries.updateManyScannerJobStates(scannerJobIds, "failed");
+            dbQueries.updateManyScannerJobStates(
+                scannerJobIds,
+                "failed",
+                "processing",
+            );
             throw new Error("Zip file unzipping failed");
         }
 
@@ -166,7 +174,11 @@ export const processPackageAndSendToScanner = async (
                     scannerJobId +
                         ': Changing ScannerJob(s) state(s) to "failed"',
                 );
-                dbQueries.updateManyScannerJobStates(scannerJobIds, "failed");
+                dbQueries.updateManyScannerJobStates(
+                    scannerJobIds,
+                    "failed",
+                    "processing",
+                );
                 throw new Error(
                     "Error: Uploading files to object storage failed",
                 );
@@ -227,12 +239,13 @@ export const processPackageAndSendToScanner = async (
     } catch (error) {
         log.error(error);
         try {
-            log.info(scannerJobId + ': Changing ScannerJob state to "failed"');
-            dbQueries.updateScannerJob(scannerJobId, { state: "failed" });
             log.info(
-                scannerJobId + ': Changing Package scanStatus to "failed"',
+                scannerJobId +
+                    ': Changing ScannerJob and children (if any) states and related Packages scanStatuses to "failed"',
             );
-            dbQueries.updateManyPackagesScanStatuses(packageIds, "failed");
+            dbQueries.updateScannerJobAndPackagesStateToFailedRecursive(
+                scannerJobId,
+            );
         } catch (error) {
             log.error(
                 scannerJobId +

--- a/apps/api/src/helpers/on_start_up.ts
+++ b/apps/api/src/helpers/on_start_up.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import log from "loglevel";
+import {
+    createSystemIssue,
+    findScannerJobsByState,
+    findSystemIssues,
+    updateManyPackagesScanStatuses,
+    updateManyScannerJobStates,
+    updateSystemIssue,
+} from "./db_queries";
+
+const logLevel: log.LogLevelDesc =
+    (process.env.LOG_LEVEL as log.LogLevelDesc) || "info"; // trace/debug/info/warn/error/silent
+
+log.setLevel(logLevel);
+
+export const onStartUp = async () => {
+    try {
+        log.info("Checking for jobs in processing state...");
+
+        const jobs = await findScannerJobsByState("processing");
+
+        log.info("Found " + jobs.length + " jobs in processing state");
+
+        if (jobs.length === 0) {
+            log.info(
+                "No jobs in processing state, moving on to start the server",
+            );
+            return;
+        }
+        log.info(
+            "Setting the state of these jobs to 'failed', as the processing was interrupted, or caused the server to become unresponsive and restart",
+        );
+        await updateManyScannerJobStates(
+            jobs.map((job) => job.id),
+            "failed",
+            "processing",
+        );
+        log.info("Also setting the scanStatus of the packages to 'failed'");
+        await updateManyPackagesScanStatuses(
+            jobs.map((job) => job.package.id),
+            "failed",
+        );
+
+        log.info("Filing SystemIssues for the jobs in processing state");
+
+        const errorCode = "PROCESSING_INTERRUPTED";
+        const severity = "LOW";
+        const msgBase =
+            "The processing of the job was interrupted by server restart for package with purl ";
+
+        for (const job of jobs) {
+            log.debug(
+                "Finding out if the job " +
+                    job.id +
+                    " has a SystemIssue already",
+            );
+            const existingIssues = await findSystemIssues(
+                errorCode,
+                msgBase + job.package.purl,
+            );
+
+            if (existingIssues.length === 0) {
+                log.debug("No SystemIssue found for job " + job.id);
+                log.info("Filing a SystemIssue for job " + job.id);
+                await createSystemIssue({
+                    message: msgBase + job.package.purl,
+                    severity: severity,
+                    errorCode: errorCode,
+                    errorType: "ScannerRouterError",
+                    info: {
+                        latestJobId: [job.id],
+                        packageId: job.package.id,
+                    },
+                });
+            } else {
+                log.info(
+                    "SystemIssue(s) found for package " + job.package.purl,
+                );
+                for (const issue of existingIssues) {
+                    if (!issue.resolved) {
+                        log.info("Updating SystemIssue");
+                        await updateSystemIssue(issue.id, {
+                            info: {
+                                latestJobId: [job.id],
+                                packageId: job.package.id,
+                            },
+                            severity: "CRITICAL",
+                            details:
+                                "Severity updated to CRITICAL as the same issue was found multiple times, which implies that the processing of this package is causing the server to restart",
+                        });
+                    } else {
+                        log.info(
+                            "Existing SystemIssue is already resolved. Creating a new one.",
+                        );
+                        await createSystemIssue({
+                            message: msgBase + job.package.purl,
+                            severity: severity,
+                            errorCode: errorCode,
+                            errorType: "ScannerRouterError",
+                            info: {
+                                latestJobId: [job.id],
+                                packageId: job.package.id,
+                            },
+                        });
+                    }
+                }
+            }
+        }
+        log.info(
+            "All jobs in processing state have been handled. Moving on to start the server.",
+        );
+    } catch (error) {
+        log.error("Error in onStartUp: " + error);
+    }
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -15,6 +15,7 @@ import { dosAPI } from "validation-helpers";
 import { getKeycloak, memoryStore } from "./config/keycloak";
 import { cronJobs } from "./cron_jobs";
 import { keycloakProtect } from "./helpers/auth_helpers";
+import { onStartUp } from "./helpers/on_start_up";
 import { adminRouter, authRouter, scannerRouter, userRouter } from "./routes";
 
 const requiredEnvVars: string[] = [
@@ -144,8 +145,13 @@ cron.schedule("*/5 * * * *", () => {
     cronJobs.jobStateQuery();
 });
 
-const PORT = process.env.PORT ? parseInt(process.env.PORT) : 5000;
+// Run onStartUp function before starting the server
+(async () => {
+    await onStartUp();
 
-app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));
+    const PORT = process.env.PORT ? parseInt(process.env.PORT) : 5000;
+
+    app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));
+})();
 
 export default app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
                 "is-glob": "4.0.3",
                 "is-valid-path": "^0.1.1",
                 "keycloak-connect": "^24.0.3",
+                "loglevel": "1.9.1",
                 "minimatch": "9.0.4",
                 "node-cache": "5.1.2",
                 "node-cron": "3.0.3",
@@ -16853,6 +16854,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/loglevel": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+            "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
             }
         },
         "node_modules/loose-envify": {

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,7 @@
         "KEYCLOAK_CLIENT_SECRET_UI",
         "KEYCLOAK_REALM",
         "KEYCLOAK_URL",
+        "LOG_LEVEL",
         "MAX_FLAG_COUNT_PROCESSING",
         "NEW_JOB_RETRIES",
         "NEW_JOB_RETRY_INTERVAL",


### PR DESCRIPTION
This PR adds a function that is run when the server starts before it starts listening to new requests, which will set any ScannerJobs that were in processing state to failed, as the processing has been interrupted. This way the detection of these cases will be faster, and won't block the scanning for a long time. Also a row in the SystemIssue table will be created, which will help in detecting cases where the processing itself caused the API to become unresponsive and restart. This PR also adds some debug logging for the processing phase. The PR also contains a commit to resolve do-587.