### PR TITLE
build: Push image to GitHub instead of Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: Build Docker image and push to Docker Hub
+name: Build and publish Docker image on Docker Hub and GitHub Packages
 
 on:
     push:
@@ -32,17 +32,26 @@ jobs:
                       ${{ runner.os }}-buildx-
 
             - name: Log in to Docker Hub
-              uses: docker/login-action@v2
+              uses: docker/login-action@v3
               with:
                   username: ${{ secrets.DOCKER_HUB_USERNAME }}
                   password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+            - name: Log in to GitHub Packages
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Build and push Docker image
-              uses: docker/build-push-action@v4
+              uses: docker/build-push-action@v6
               continue-on-error: false
               with:
                   context: .
                   push: true
-                  tags: ${{ secrets.DOCKER_HUB_USERNAME }}/worker:latest
+                  tags: |
+                      ${{ secrets.DOCKER_HUB_USERNAME }}/worker:latest
+                      ghcr.io/${{ github.repository }}/worker:latest
                   cache-from: type=local,src=/tmp/.buildx-cache
                   cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
This makes the image easier to find and is consistent with ORT and ORT Server.