### PR TITLE
Adjust Minio healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,11 +51,10 @@ services:
         command: server --console-address ":9001" /data
         restart: always
         healthcheck:
-            test:
-                ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-            interval: 30s
-            timeout: 20s
-            retries: 3
+            test: ["CMD", "mc", "ready", "local"]
+            interval: 1s
+            timeout: 1s
+            retries: 20
 
     createbuckets:
         image: minio/mc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,9 @@ services:
     createbuckets:
         image: minio/mc
         depends_on:
-            - minio
+            minio:
+                condition: service_healthy
+                required: true
         entrypoint: >
             /bin/sh -c "
             /usr/bin/mc alias set myminio http://minio:9000 miniouser miniopassword;


### PR DESCRIPTION
The default condition is service started [1], but we should wait for it to be
healthy.

[1]: https://docs.docker.com/reference/compose-file/services/#long-syntax-1

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>