### PR TITLE
Use Turbo inside API's Dockerfile

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,7 +52,7 @@ jobs:
             - name: Seed the database and populate the spaces bucket
               run: npm run db:migrate:reset
             - name: Run Playwright tests
-              run: npm run test:cui:e2e
+              run: npm run test:e2e
             - name: Print Docker Compose logs
               run: docker compose logs
               if: failure()

--- a/API.Dockerfile
+++ b/API.Dockerfile
@@ -7,6 +7,10 @@ FROM node:20.10.0
 
 WORKDIR /app/dos
 
+# Use the major version installed locally in the project. When updating the local version, update
+# this as well.
+RUN npm install -g turbo@2
+
 COPY package.json ./package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY packages/database/package.json ./packages/database/package.json
@@ -22,4 +26,6 @@ RUN npm run db:generate
 
 RUN npm run build:api
 
-CMD cd apps/api && npm run start
+ENTRYPOINT [ "turbo" ]
+
+CMD [ "run", "start", "--filter=api", "--no-cache", "--no-daemon" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,17 @@ services:
             exit 0;
             "
 
+    run-migrations:
+        build:
+            dockerfile: API.Dockerfile
+        command: ["run", "db:migrate:deploy"]
+        environment:
+            - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
+        depends_on:
+            postgres:
+                condition: service_healthy
+                required: true
+
     api:
         build:
             dockerfile: API.Dockerfile
@@ -88,6 +99,9 @@ services:
         depends_on:
             postgres:
                 condition: service_healthy
+                required: true
+            run-migrations:
+                condition: service_completed_successfully
                 required: true
             redis:
                 condition: service_healthy


### PR DESCRIPTION
Update the Dockerfile for the API to use Turbo as the entrypoint and default command. This allows for specifying other commands for the image at runtime, making it possible to use the same image as an initContainer in Kubernetes to run database migrations.