### PR TITLE
Use newly deployed API URL on Scaleway

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,7 @@ jobs:
               continue-on-error: false
               with:
                   build-args: |
-                      NEXT_PUBLIC_API_URL=https://api.doubleopen.io/api/
+                      NEXT_PUBLIC_API_URL=https://dos-api.scw.doubleopen.io/api/
                   context: .
                   file: "UI.Dockerfile"
                   push: true


### PR DESCRIPTION
This can be changed back after the new API is confirmed to work and DNS has been updated.