### PR TITLE
build: Rollback DOS API URL

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,7 @@ jobs:
               continue-on-error: false
               with:
                   build-args: |
-                      NEXT_PUBLIC_API_URL=https://dos-api.scw.doubleopen.io/api/
+                      NEXT_PUBLIC_API_URL=https://api.doubleopen.io/api/
                   context: .
                   file: "UI.Dockerfile"
                   push: true


### PR DESCRIPTION
The new one doesn't work.

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>