### PR TITLE
ci: Fix reference to environment variable in Docker job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,7 +109,7 @@ jobs:
               continue-on-error: false
               with:
                   build-args: |
-                      NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+                      NEXT_PUBLIC_API_URL=${{ env.NEXT_PUBLIC_API_URL }}
                   context: .
                   file: "UI.Dockerfile"
                   push: true


### PR DESCRIPTION
The simple way to refer to the environment doesn't work.

This is a fixup for 8a6aed4e.

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>