### PR TITLE
fix(api): Edit parsing of qualifiers from purl

### DIFF
--- a/apps/api/src/helpers/purl_helpers.ts
+++ b/apps/api/src/helpers/purl_helpers.ts
@@ -7,23 +7,12 @@ import { PackageURL } from "packageurl-js";
 export const parsePurl = (purl: string) => {
     const parsedPurl = PackageURL.fromString(purl);
 
-    let qualifiers = undefined;
-
-    if (parsedPurl.qualifiers) {
-        for (const [key, value] of Object.entries(parsedPurl.qualifiers)) {
-            if (qualifiers) {
-                qualifiers += "&" + key + "=" + encodeURIComponent(value);
-            } else {
-                qualifiers = key + "=" + encodeURIComponent(value);
-            }
-        }
-    }
     return {
         type: parsedPurl.type,
         namespace: parsedPurl.namespace,
         name: parsedPurl.name,
         version: parsedPurl.version,
-        qualifiers: qualifiers,
+        qualifiers: purl.split("#")[0].split("?")[1],
         subpath: parsedPurl.subpath,
     };
 };

--- a/apps/api/tests/suites/helpers.spec.ts
+++ b/apps/api/tests/suites/helpers.spec.ts
@@ -10,7 +10,7 @@ export default function suite(): void {
     describe("Testing purl helpers", function () {
         it("should decode a RepositoryProvenance PURL into its main components", function () {
             const purl =
-                "pkg:npm/%40floating-ui/core@1.5.2?vcs_type=Git&vcs_url=https%3A%2F%2Fgithub.com%2Ffloating-ui%2Ffloating-ui.git&vcs_revision=78e8d87ec2fd2172921937e24390806d7dedb636&resolved_revision=78e8d87ec2fd2172921937e24390806d7dedb636#packages/core";
+                "pkg:npm/%40floating-ui/core@1.5.2?vcs_type=Git&vcs_url=https://github.com/floating-ui/floating-ui.git&vcs_revision=78e8d87ec2fd2172921937e24390806d7dedb636&resolved_revision=78e8d87ec2fd2172921937e24390806d7dedb636#packages/core";
             const parsedPurl = parsePurl(purl);
 
             assert.strictEqual(parsedPurl.type, "npm");
@@ -19,14 +19,14 @@ export default function suite(): void {
             assert.strictEqual(parsedPurl.version, "1.5.2");
             assert.strictEqual(
                 parsedPurl.qualifiers,
-                "vcs_type=Git&vcs_url=https%3A%2F%2Fgithub.com%2Ffloating-ui%2Ffloating-ui.git&vcs_revision=78e8d87ec2fd2172921937e24390806d7dedb636&resolved_revision=78e8d87ec2fd2172921937e24390806d7dedb636",
+                "vcs_type=Git&vcs_url=https://github.com/floating-ui/floating-ui.git&vcs_revision=78e8d87ec2fd2172921937e24390806d7dedb636&resolved_revision=78e8d87ec2fd2172921937e24390806d7dedb636",
             );
             assert.strictEqual(parsedPurl.subpath, "packages/core");
         });
 
         it("should decode an ArtifactProvenance PURL into its main components", function () {
             const purl =
-                "pkg:npm/%40radix-ui/react-context@1.0.0?download_url=https%3A%2F%2Fregistry.npmjs.org%2F%40radix-ui%2Freact-context%2F-%2Freact-context-1.0.0.tgz&checksum=sha1%3Af38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0";
+                "pkg:npm/%40radix-ui/react-context@1.0.0?download_url=https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz&checksum=sha1:f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0";
             const parsedPurl = parsePurl(purl);
 
             assert.strictEqual(parsedPurl.type, "npm");
@@ -35,14 +35,14 @@ export default function suite(): void {
             assert.strictEqual(parsedPurl.version, "1.0.0");
             assert.strictEqual(
                 parsedPurl.qualifiers,
-                "download_url=https%3A%2F%2Fregistry.npmjs.org%2F%40radix-ui%2Freact-context%2F-%2Freact-context-1.0.0.tgz&checksum=sha1%3Af38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0",
+                "download_url=https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz&checksum=sha1:f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0",
             );
             assert.strictEqual(parsedPurl.subpath, undefined);
         });
 
         it("should uri encode all qualifier values", function () {
             const purl =
-                "pkg:maven/commons-beanutils/commons-beanutils@1.9.4?vcs_type=Subversion&vcs_url=http%3A%2F%2Fsvn.apache.org%2Frepos%2Fasf%2Fcommons%2Fproper%2Fbeanutils&vcs_revision=tags%2FBEANUTILS_1_9_3_RC3&resolved_revision=603598";
+                "pkg:maven/commons-beanutils/commons-beanutils@1.9.4?vcs_type=Subversion&vcs_url=http://svn.apache.org/repos/asf/commons/proper/beanutils&vcs_revision=tags/BEANUTILS_1_9_3_RC3&resolved_revision=603598";
             const parsedPurl = parsePurl(purl);
 
             assert.strictEqual(parsedPurl.type, "maven");
@@ -51,7 +51,7 @@ export default function suite(): void {
             assert.strictEqual(parsedPurl.version, "1.9.4");
             assert.strictEqual(
                 parsedPurl.qualifiers,
-                "vcs_type=Subversion&vcs_url=http%3A%2F%2Fsvn.apache.org%2Frepos%2Fasf%2Fcommons%2Fproper%2Fbeanutils&vcs_revision=tags%2FBEANUTILS_1_9_3_RC3&resolved_revision=603598",
+                "vcs_type=Subversion&vcs_url=http://svn.apache.org/repos/asf/commons/proper/beanutils&vcs_revision=tags/BEANUTILS_1_9_3_RC3&resolved_revision=603598",
             );
             assert.strictEqual(parsedPurl.subpath, undefined);
         });


### PR DESCRIPTION
As the qualifiers are saved as a string in the database and the individual key value pairs are not saved or processed separately, and their processing is causing inconvenient errors, parse the qualifier string straight from the purl as is.