### PR TITLE
Pass ScanCode logs through to Scanner Worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
         environment:
             - REDIS_URL=redis://redis:6379
             - SPACES_ENDPOINT=http://minio:9000
+            - DEBUG=true
         depends_on:
             - redis
             - minio

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,7 @@
         "DB_CONCURRENCY",
         "DB_RETRIES",
         "DB_RETRY_INTERVAL",
+        "DEBUG",
         "DL_CONCURRENCY",
         "E2E_USER_USERNAME",
         "E2E_USER_PASSWORD",


### PR DESCRIPTION
ScanCode pipes the output to stdout and logs to stderr. Allow adding more logs with environment variable DEBUG.