### PR TITLE
fix: Fix breaking changes from Keycloak version upgrade 

### DIFF
--- a/apps/api/src/@types/express.d.ts
+++ b/apps/api/src/@types/express.d.ts
@@ -42,6 +42,9 @@ declare namespace Express {
                         sid: string;
                         email_verified: boolean;
                         preferred_username: string;
+                        email: string;
+                        given_name: string;
+                        family_name: string;
                     };
                     signature: Buffer | unknown;
                     signed: string;

--- a/apps/api/src/routes/user_router.ts
+++ b/apps/api/src/routes/user_router.ts
@@ -64,6 +64,10 @@ userRouter.put("/token", async (req, res) => {
 
         // Update user token
         await updateUser(req.kauth.grant.access_token.content.sub, {
+            username: req.kauth.grant.access_token.content.preferred_username,
+            email: req.kauth.grant.access_token.content.email,
+            firstName: req.kauth.grant.access_token.content.given_name,
+            lastName: req.kauth.grant.access_token.content.family_name,
             attributes: { dosApiToken: token },
         });
 

--- a/apps/clearance_ui/tests/e2e/global.setup.ts
+++ b/apps/clearance_ui/tests/e2e/global.setup.ts
@@ -28,7 +28,7 @@ setup("logs in", async ({ page }) => {
     await page.fill("#password", process.env.E2E_USER_PASSWORD);
 
     // Submit login form
-    await page.click('input[type="submit"]');
+    await page.click('button[type="submit"]');
 
     // Expect to be redirected to the home page
     await expect(


### PR DESCRIPTION
Send the username, email, first name and last name in the update user request when updating a user's attributes as otherwise they would be nullified, and a missing username results in an error in the request.

Also change the selector of the "Sign in" button in the UI Playwright tests, as the button is now a button instead of an input.