### PR TITLE
refactor(worker): Edit ScanCode options

### DIFF
--- a/apps/scanner_worker/src/index.ts
+++ b/apps/scanner_worker/src/index.ts
@@ -146,7 +146,7 @@ const start = (): void => {
 
         // Spawn a child process to run ScanCode inside this container
         const options: (string | undefined)[] = [
-            "-clp",
+            "-cl",
             "-i",
             // Enable debug logs if DEBUG env variable is set.
             process.env.DEBUG ? "-v" : undefined,


### PR DESCRIPTION
Remove the `-p` option from ScanCode options, as it doesn't provide information that is taken into use, and is likely causing higher memory consumption and performance issues.