### PR TITLE
ci(renovate): Configure Renovate to sync Node.js versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,17 @@
     "extends": ["config:recommended"],
     "schedule": ["after 9am and before 7pm every weekday"],
     "timezone": "Europe/Tallinn",
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": ["^\\.github/workflows/.*\\.yml$"],
+            "matchStrings": [
+                "node-version:\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+            ],
+            "depNameTemplate": "node",
+            "datasourceTemplate": "node"
+        }
+    ],
     "packageRules": [
         {
             "matchPackageNames": ["@zodios/express"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
-    "schedule": ["after 9am and before 7pm on every weekday"],
+    "schedule": ["after 9am and before 7pm every weekday"],
     "timezone": "Europe/Tallinn",
     "packageRules": [
         {


### PR DESCRIPTION
Ensure that the Node.js versions in the action workflows are updated when the Node.js group is updated by adding a custom manager [1] to help detect the Node.js dependencies in the workflow files. They should now match the preset group `group:nodeJs` [2].

[1]: https://docs.renovatebot.com/modules/manager/regex/
[2]: https://docs.renovatebot.com/presets-group/#groupnodejs