### PR TITLE
ci(renovate): Remove grouping for linting plugins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,13 +44,6 @@
             "allowedVersions": ">=8.2.4 <8.3.4 || >8.3.5"
         },
         {
-            "groupName": "eslint and related plugins",
-            "matchFileNames": [
-                "packages/eslint-config-custom-server/package.json",
-                "packages/eslint-config-custom/package.json"
-            ]
-        },
-        {
             "extends": ["monorepo:aws-sdk-js-v3"],
             "groupName": "aws-sdk-js-v3 monorepo",
             "schedule": ["after 9am on monday"]


### PR DESCRIPTION
Remove grouping to see if it's causing some unexpected issues with Renovate switching between versions 14.2.23 and 15.1.5 for the `@next/eslint-plugin-next` dependency.