### PR TITLE
ci(renovate): Pin beautifulsoup4 to v4.12.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,10 @@
             "extends": ["monorepo:aws-sdk-js-v3"],
             "groupName": "aws-sdk-js-v3 monorepo",
             "schedule": ["after 9am on monday"]
+        },
+        {
+            "matchPackageNames": ["beautifulsoup4"],
+            "allowedVersions": "4.12.x"
         }
     ],
     "prHourlyLimit": 5


### PR DESCRIPTION
Looks like renovate is creating update requests for the Python packages now that they are are defined in a separate requirements.txt file, so also pin the version in renovate configuration. See related commit https://github.com/doubleopen-project/dos/commit/ac8d65a58286c9cc781e2f25aa1fd6a663370742.