### PR TITLE
Add support for changing user ID for clearance items

### DIFF
--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -3686,6 +3686,92 @@ export const findSystemIssues = async (
     return systemIssues;
 };
 
+export const getDistinctUserIdsForItems = async (): Promise<Set<string>> => {
+    let retries = initialRetryCount;
+    const userIds: Set<string> = new Set();
+
+    while (retries > 0) {
+        try {
+            const items = await prisma.licenseConclusion.findMany({
+                select: {
+                    userId: true,
+                },
+                distinct: ["userId"],
+            });
+
+            for (const item of items) {
+                userIds.add(item.userId);
+            }
+            break;
+        } catch (error) {
+            console.log(
+                "Error with trying to find distinct userIds for items: " +
+                    error,
+            );
+            handleError(error);
+            retries--;
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    retries = initialRetryCount;
+
+    while (retries > 0) {
+        try {
+            const items = await prisma.bulkConclusion.findMany({
+                select: {
+                    userId: true,
+                },
+                distinct: ["userId"],
+            });
+
+            for (const item of items) {
+                userIds.add(item.userId);
+            }
+            break;
+        } catch (error) {
+            console.log(
+                "Error with trying to find distinct userIds for items: " +
+                    error,
+            );
+            handleError(error);
+            retries--;
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    retries = initialRetryCount;
+
+    while (retries > 0) {
+        try {
+            const items = await prisma.pathExclusion.findMany({
+                select: {
+                    userId: true,
+                },
+                distinct: ["userId"],
+            });
+
+            for (const item of items) {
+                userIds.add(item.userId);
+            }
+            break;
+        } catch (error) {
+            console.log(
+                "Error with trying to find distinct userIds for items: " +
+                    error,
+            );
+            handleError(error);
+            retries--;
+            if (retries > 0) await waitToRetry();
+            else throw error;
+        }
+    }
+
+    return userIds;
+};
+
 // ------------------------------ Delete ------------------------------
 
 // Delete all license findings related to files

--- a/apps/api/tests/e2e/admin_router.spec.ts
+++ b/apps/api/tests/e2e/admin_router.spec.ts
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 import test, { APIRequestContext, expect } from "@playwright/test";
+import {
+    createLicenseConclusion,
+    deleteLicenseConclusion,
+} from "../../src/helpers/db_queries";
+import { getUsers } from "../../src/helpers/keycloak_queries";
 import { getAccessToken } from "./utils/get_access_token";
 
 const baseUrl = process.env.CI ? "http://api:3001" : "http://localhost:5000";
@@ -47,6 +52,95 @@ test.describe("API lets authenticated admins to", () => {
     });
 });
 
+test.describe("API lets authenticated admins to", () => {
+    let keycloakToken: string;
+    let adminUserId: string;
+    let apiContext: APIRequestContext;
+    const testPurl =
+        "pkg:npm/dos-monorepo@0.0.0?vcs_type=Git&vcs_url=https%3A%2F%2Fgithub.com%2Fdoubleopen-project%2Fdos.git&vcs_revision=dc27d024ea5c001def72122c8c0f8c148cec39b6&resolved_revision=dc27d024ea5c001def72122c8c0f8c148cec39b6";
+    const licenseConclusionIds: number[] = [];
+
+    test.beforeAll(async ({ playwright }) => {
+        const adminUser = await getUsers("test-admin");
+        expect(adminUser).toBeDefined();
+        expect(adminUser.length).toBe(1);
+        adminUserId = adminUser[0].id;
+
+        // Retrieve the access token for the admin user from Keycloak.
+        keycloakToken = await getAccessToken("test-admin", "test-admin");
+        expect(keycloakToken).toBeDefined();
+
+        // Create a new API context for the admin API with the Keycloak token in the headers.
+        apiContext = await playwright.request.newContext({
+            baseURL: `${baseUrl}/api/admin/`,
+            extraHTTPHeaders: {
+                Authorization: `Bearer ${keycloakToken}`,
+            },
+        });
+
+        // Add license conclusions for the tests.
+        const licenseConclusion1 = await createLicenseConclusion({
+            concludedLicenseExpressionSPDX: "MIT",
+            detectedLicenseExpressionSPDX:
+                "MIT AND (CC0-1.0 AND GPL-2.0-only AND BSD-3-Clause) AND (MIT AND BSD-2-Clause AND GPL-2.0-only AND GCC-exception-2.0 AND CC-BY-3.0)",
+            comment: null,
+            local: undefined,
+            contextPurl: testPurl,
+            fileSha256:
+                "0cbc1f28243bae937e4a2ca774779471484a8b73cf901d0db68ac1642d8c6828",
+            userId: adminUserId,
+        });
+        licenseConclusionIds.push(licenseConclusion1.id);
+
+        const licenseConclusion2 = await createLicenseConclusion({
+            concludedLicenseExpressionSPDX: "MIT",
+            detectedLicenseExpressionSPDX:
+                "MIT AND LicenseRef-scancode-free-unknown",
+            comment: null,
+            local: undefined,
+            contextPurl: testPurl,
+            fileSha256:
+                "3033e4e29fa8ea20d8936e68e3f31d53ae6d34912c7c9ebc30709d4481356f50",
+            userId: adminUserId,
+        });
+
+        licenseConclusionIds.push(licenseConclusion2.id);
+    });
+
+    test.afterAll(async () => {
+        // Clean up by removing the license conclusions.
+        for (const id of licenseConclusionIds) {
+            await deleteLicenseConclusion(id);
+        }
+        // Dispose of the API context to clean up resources.
+        await apiContext.dispose();
+    });
+
+    test("retrieve data on distinct users that have made clearance items", async () => {
+        const distinctUsersRes = await apiContext.get(
+            "clearance-items/distinct-users",
+        );
+        expect(distinctUsersRes.ok()).toBe(true);
+
+        const distinctUsers = await distinctUsersRes.json();
+        expect(distinctUsers.users.length).toBeGreaterThan(0);
+
+        expect(distinctUsers.users).toContainEqual(
+            expect.objectContaining({
+                id: adminUserId,
+                username: "test-admin",
+            }),
+        );
+
+        // Expect to find the admin user ID in the list of distinct user IDs only once.
+        const userIdCount = distinctUsers.users.filter(
+            (user: { id: string; username: string | undefined }) =>
+                user.id === adminUserId,
+        ).length;
+        expect(userIdCount).toBe(1);
+    });
+});
+
 test.describe("API doesn't let authenticated regular users to", () => {
     let apiContext: APIRequestContext;
     let keycloakToken;
@@ -77,6 +171,11 @@ test.describe("API doesn't let authenticated regular users to", () => {
 
     test("retrieve count for packages", async () => {
         const response = await apiContext.get("packages/count");
+        expect(response.status()).toBe(403);
+    });
+
+    test("retrieve data on distinct users that have made clearance items", async () => {
+        const response = await apiContext.get("clearance-items/distinct-users");
         expect(response.status()).toBe(403);
     });
 });
@@ -112,6 +211,11 @@ test.describe("API doesn't let readonly users to", () => {
         const response = await apiContext.get("packages/count");
         expect(response.status()).toBe(403);
     });
+
+    test("retrieve data on distinct users that have made clearance items", async () => {
+        const response = await apiContext.get("clearance-items/distinct-users");
+        expect(response.status()).toBe(403);
+    });
 });
 
 test.describe("API doesn't let unauthenticated users to", () => {
@@ -138,6 +242,12 @@ test.describe("API doesn't let unauthenticated users to", () => {
     test("retrieve count for packages", async () => {
         // Attempt to retrieve package count without authentication.
         const response = await apiContext.get("packages/count");
+        expect(response.status()).toBe(401);
+    });
+
+    test("retrieve data on distinct users that have made clearance items", async () => {
+        // Attempt to retrieve distinct users without authentication.
+        const response = await apiContext.get("clearance-items/distinct-users");
         expect(response.status()).toBe(401);
     });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,7 @@ services:
             args:
                 - NEXT_PUBLIC_API_URL=http://api:3001/api/
         environment:
+            - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
             - KEYCLOAK_URL=http://keycloak:8080
             - CI=true
         depends_on:

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -19686,6 +19686,88 @@ declare const keycloakAPI: [
             },
         ];
     },
+    {
+        method: "get";
+        path: "/admin/realms/:realm/users/:id";
+        description: "Get user by ID";
+        alias: "GetUserById";
+        response: zod.ZodObject<
+            {
+                id: zod.ZodString;
+                username: zod.ZodString;
+                firstName: zod.ZodOptional<zod.ZodString>;
+                lastName: zod.ZodOptional<zod.ZodString>;
+                email: zod.ZodOptional<zod.ZodString>;
+                attributes: zod.ZodOptional<
+                    zod.ZodObject<
+                        {
+                            dosApiToken: zod.ZodOptional<
+                                zod.ZodArray<zod.ZodString, "many">
+                            >;
+                        },
+                        "strip",
+                        zod.ZodTypeAny,
+                        {
+                            dosApiToken?: string[] | undefined;
+                        },
+                        {
+                            dosApiToken?: string[] | undefined;
+                        }
+                    >
+                >;
+                requiredActions: zod.ZodOptional<
+                    zod.ZodArray<zod.ZodString, "many">
+                >;
+            },
+            "strip",
+            zod.ZodTypeAny,
+            {
+                username: string;
+                id: string;
+                firstName?: string | undefined;
+                lastName?: string | undefined;
+                email?: string | undefined;
+                attributes?:
+                    | {
+                          dosApiToken?: string[] | undefined;
+                      }
+                    | undefined;
+                requiredActions?: string[] | undefined;
+            },
+            {
+                username: string;
+                id: string;
+                firstName?: string | undefined;
+                lastName?: string | undefined;
+                email?: string | undefined;
+                attributes?:
+                    | {
+                          dosApiToken?: string[] | undefined;
+                      }
+                    | undefined;
+                requiredActions?: string[] | undefined;
+            }
+        >;
+        errors: [
+            {
+                status: 400;
+                description: "Bad request";
+                schema: zod.ZodObject<
+                    {
+                        error: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        error: string;
+                    },
+                    {
+                        error: string;
+                    }
+                >;
+            },
+        ];
+    },
 ];
 
 declare const TokenResponse: z.ZodObject<

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -1707,6 +1707,165 @@ declare const adminAPI: [
             },
         ];
     },
+    {
+        method: "put";
+        path: "/clearance-items/reassign";
+        description: "Reassign clearance items to a new user ID";
+        parameters: [
+            {
+                name: "body";
+                type: "Body";
+                schema: zod.ZodObject<
+                    {
+                        userId: zod.ZodString;
+                        newUserId: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        userId: string;
+                        newUserId: string;
+                    },
+                    {
+                        userId: string;
+                        newUserId: string;
+                    }
+                >;
+            },
+        ];
+        response: zod.ZodObject<
+            {
+                message: zod.ZodString;
+                counts: zod.ZodObject<
+                    {
+                        pathExclusions: zod.ZodNumber;
+                        bulkConclusions: zod.ZodNumber;
+                        licenseConclusions: zod.ZodNumber;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        pathExclusions: number;
+                        bulkConclusions: number;
+                        licenseConclusions: number;
+                    },
+                    {
+                        pathExclusions: number;
+                        bulkConclusions: number;
+                        licenseConclusions: number;
+                    }
+                >;
+            },
+            "strip",
+            zod.ZodTypeAny,
+            {
+                message: string;
+                counts: {
+                    pathExclusions: number;
+                    bulkConclusions: number;
+                    licenseConclusions: number;
+                };
+            },
+            {
+                message: string;
+                counts: {
+                    pathExclusions: number;
+                    bulkConclusions: number;
+                    licenseConclusions: number;
+                };
+            }
+        >;
+        errors: [
+            {
+                status: 500;
+                description: "Internal server error";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 400;
+                description: "Bad request";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                        path: zod.ZodOptional<zod.ZodNullable<zod.ZodString>>;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    },
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    }
+                >;
+            },
+            {
+                status: 403;
+                description: "Forbidden";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 401;
+                description: "Unauthorized";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 404;
+                description: "Not found";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+        ];
+    },
 ];
 
 declare const authAPI: [
@@ -2515,29 +2674,29 @@ declare const scannerAPI: [
             "strip",
             zod.ZodTypeAny,
             {
+                pathExclusions: {
+                    comment: string | null;
+                    pattern: string;
+                    reason: string;
+                }[];
                 licenseConclusions: {
                     path: string;
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
-                }[];
-                pathExclusions: {
-                    comment: string | null;
-                    pattern: string;
-                    reason: string;
                 }[];
             },
             {
+                pathExclusions: {
+                    comment: string | null;
+                    pattern: string;
+                    reason: string;
+                }[];
                 licenseConclusions: {
                     path: string;
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
-                }[];
-                pathExclusions: {
-                    comment: string | null;
-                    pattern: string;
-                    reason: string;
                 }[];
             }
         >;
@@ -10361,29 +10520,29 @@ declare const dosAPI: [
             "strip",
             zod.ZodTypeAny,
             {
+                pathExclusions: {
+                    comment: string | null;
+                    pattern: string;
+                    reason: string;
+                }[];
                 licenseConclusions: {
                     path: string;
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
-                }[];
-                pathExclusions: {
-                    comment: string | null;
-                    pattern: string;
-                    reason: string;
                 }[];
             },
             {
+                pathExclusions: {
+                    comment: string | null;
+                    pattern: string;
+                    reason: string;
+                }[];
                 licenseConclusions: {
                     path: string;
                     detectedLicenseExpressionSPDX: string | null;
                     concludedLicenseExpressionSPDX: string;
                     comment: string | null;
-                }[];
-                pathExclusions: {
-                    comment: string | null;
-                    pattern: string;
-                    reason: string;
                 }[];
             }
         >;
@@ -18632,6 +18791,165 @@ declare const dosAPI: [
                     id: string;
                     username?: string | undefined;
                 }[];
+            }
+        >;
+        errors: [
+            {
+                status: 500;
+                description: "Internal server error";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 400;
+                description: "Bad request";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                        path: zod.ZodOptional<zod.ZodNullable<zod.ZodString>>;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    },
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    }
+                >;
+            },
+            {
+                status: 403;
+                description: "Forbidden";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 401;
+                description: "Unauthorized";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 404;
+                description: "Not found";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+        ];
+    },
+    {
+        method: "put";
+        path: "/admin/clearance-items/reassign";
+        description: "Reassign clearance items to a new user ID";
+        parameters: [
+            {
+                name: "body";
+                type: "Body";
+                schema: zod.ZodObject<
+                    {
+                        userId: zod.ZodString;
+                        newUserId: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        userId: string;
+                        newUserId: string;
+                    },
+                    {
+                        userId: string;
+                        newUserId: string;
+                    }
+                >;
+            },
+        ];
+        response: zod.ZodObject<
+            {
+                message: zod.ZodString;
+                counts: zod.ZodObject<
+                    {
+                        pathExclusions: zod.ZodNumber;
+                        bulkConclusions: zod.ZodNumber;
+                        licenseConclusions: zod.ZodNumber;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        pathExclusions: number;
+                        bulkConclusions: number;
+                        licenseConclusions: number;
+                    },
+                    {
+                        pathExclusions: number;
+                        bulkConclusions: number;
+                        licenseConclusions: number;
+                    }
+                >;
+            },
+            "strip",
+            zod.ZodTypeAny,
+            {
+                message: string;
+                counts: {
+                    pathExclusions: number;
+                    bulkConclusions: number;
+                    licenseConclusions: number;
+                };
+            },
+            {
+                message: string;
+                counts: {
+                    pathExclusions: number;
+                    bulkConclusions: number;
+                    licenseConclusions: number;
+                };
             }
         >;
         errors: [

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -1575,6 +1575,138 @@ declare const adminAPI: [
             },
         ];
     },
+    {
+        method: "get";
+        path: "/clearance-items/distinct-users";
+        description: "Get information about the distinct users that have made clearance items";
+        response: zod.ZodObject<
+            {
+                users: zod.ZodArray<
+                    zod.ZodObject<
+                        {
+                            id: zod.ZodString;
+                            username: zod.ZodOptional<zod.ZodString>;
+                        },
+                        "strip",
+                        zod.ZodTypeAny,
+                        {
+                            id: string;
+                            username?: string | undefined;
+                        },
+                        {
+                            id: string;
+                            username?: string | undefined;
+                        }
+                    >,
+                    "many"
+                >;
+            },
+            "strip",
+            zod.ZodTypeAny,
+            {
+                users: {
+                    id: string;
+                    username?: string | undefined;
+                }[];
+            },
+            {
+                users: {
+                    id: string;
+                    username?: string | undefined;
+                }[];
+            }
+        >;
+        errors: [
+            {
+                status: 500;
+                description: "Internal server error";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 400;
+                description: "Bad request";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                        path: zod.ZodOptional<zod.ZodNullable<zod.ZodString>>;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    },
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    }
+                >;
+            },
+            {
+                status: 403;
+                description: "Forbidden";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 401;
+                description: "Unauthorized";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 404;
+                description: "Not found";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+        ];
+    },
 ];
 
 declare const authAPI: [
@@ -18368,6 +18500,138 @@ declare const dosAPI: [
             },
             {
                 count: number;
+            }
+        >;
+        errors: [
+            {
+                status: 500;
+                description: "Internal server error";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 400;
+                description: "Bad request";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                        path: zod.ZodOptional<zod.ZodNullable<zod.ZodString>>;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    },
+                    {
+                        message: string;
+                        path?: string | null | undefined;
+                    }
+                >;
+            },
+            {
+                status: 403;
+                description: "Forbidden";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 401;
+                description: "Unauthorized";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+            {
+                status: 404;
+                description: "Not found";
+                schema: zod.ZodObject<
+                    {
+                        message: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        message: string;
+                    },
+                    {
+                        message: string;
+                    }
+                >;
+            },
+        ];
+    },
+    {
+        method: "get";
+        path: "/admin/clearance-items/distinct-users";
+        description: "Get information about the distinct users that have made clearance items";
+        response: zod.ZodObject<
+            {
+                users: zod.ZodArray<
+                    zod.ZodObject<
+                        {
+                            id: zod.ZodString;
+                            username: zod.ZodOptional<zod.ZodString>;
+                        },
+                        "strip",
+                        zod.ZodTypeAny,
+                        {
+                            id: string;
+                            username?: string | undefined;
+                        },
+                        {
+                            id: string;
+                            username?: string | undefined;
+                        }
+                    >,
+                    "many"
+                >;
+            },
+            "strip",
+            zod.ZodTypeAny,
+            {
+                users: {
+                    id: string;
+                    username?: string | undefined;
+                }[];
+            },
+            {
+                users: {
+                    id: string;
+                    username?: string | undefined;
+                }[];
             }
         >;
         errors: [

--- a/packages/validation-helpers/src/api/apis/admin.ts
+++ b/packages/validation-helpers/src/api/apis/admin.ts
@@ -232,4 +232,18 @@ export const adminAPI = makeApi([
         response: schemas.GetDistinctUsersForItemsRes,
         errors,
     },
+    {
+        method: "put",
+        path: "/clearance-items/reassign",
+        description: "Reassign clearance items to a new user ID",
+        parameters: [
+            {
+                name: "body",
+                type: "Body",
+                schema: schemas.PutReassignClearanceItemsReq,
+            },
+        ],
+        response: schemas.PutReassignClearanceItemsRes,
+        errors,
+    },
 ]);

--- a/packages/validation-helpers/src/api/apis/admin.ts
+++ b/packages/validation-helpers/src/api/apis/admin.ts
@@ -224,4 +224,12 @@ export const adminAPI = makeApi([
         response: commonSchemas.GetCountRes,
         errors,
     },
+    {
+        method: "get",
+        path: "/clearance-items/distinct-users",
+        description:
+            "Get information about the distinct users that have made clearance items",
+        response: schemas.GetDistinctUsersForItemsRes,
+        errors,
+    },
 ]);

--- a/packages/validation-helpers/src/api/schemas/admin_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/admin_schemas.ts
@@ -105,3 +105,11 @@ export const GetPackagesRes = z.object({
         }),
     ),
 });
+
+//---------------- GET distinct user IDs ----------------
+
+export const GetDistinctUsersForItemsRes = z.object({
+    users: z.array(
+        z.object({ id: z.string(), username: z.string().optional() }),
+    ),
+});

--- a/packages/validation-helpers/src/api/schemas/admin_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/admin_schemas.ts
@@ -113,3 +113,19 @@ export const GetDistinctUsersForItemsRes = z.object({
         z.object({ id: z.string(), username: z.string().optional() }),
     ),
 });
+
+//---------------- PUT reassign clearance items ----------------
+
+export const PutReassignClearanceItemsReq = z.object({
+    userId: z.string().uuid(),
+    newUserId: z.string().uuid(),
+});
+
+export const PutReassignClearanceItemsRes = z.object({
+    message: z.string(),
+    counts: z.object({
+        pathExclusions: z.number(),
+        bulkConclusions: z.number(),
+        licenseConclusions: z.number(),
+    }),
+});

--- a/packages/validation-helpers/src/kc/api.ts
+++ b/packages/validation-helpers/src/kc/api.ts
@@ -210,4 +210,12 @@ export const keycloakAPI = makeApi([
         response: schemas.UndefinedResponse,
         errors,
     },
+    {
+        method: "get",
+        path: "/admin/realms/:realm/users/:id",
+        description: "Get user by ID",
+        alias: "GetUserById",
+        response: schemas.GetUserByIdResponse,
+        errors,
+    },
 ]);

--- a/packages/validation-helpers/src/kc/schemas.ts
+++ b/packages/validation-helpers/src/kc/schemas.ts
@@ -85,21 +85,21 @@ export const CreateUserReq = z.object({
 
 export const UndefinedResponse = z.undefined();
 
-export const GetUsersResponse = z.array(
-    z.object({
-        id: z.string(),
-        username: z.string(),
-        firstName: z.string().optional(),
-        lastName: z.string().optional(),
-        email: z.string().optional(),
-        attributes: z
-            .object({
-                dosApiToken: z.array(z.string()).optional(),
-            })
-            .optional(),
-        requiredActions: z.array(z.string()).optional(),
-    }),
-);
+const UserRepresentation = z.object({
+    id: z.string(),
+    username: z.string(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    email: z.string().optional(),
+    attributes: z
+        .object({
+            dosApiToken: z.array(z.string()).optional(),
+        })
+        .optional(),
+    requiredActions: z.array(z.string()).optional(),
+});
+
+export const GetUsersResponse = z.array(UserRepresentation);
 
 export const RealmRole = z.object({
     id: z.string(),
@@ -141,3 +141,5 @@ export const ResetUserPasswordReq = z.object({
     value: z.string(),
     temporary: z.boolean(),
 });
+
+export const GetUserByIdResponse = UserRepresentation;

--- a/terraform/keycloak.tf
+++ b/terraform/keycloak.tf
@@ -371,6 +371,8 @@ resource "keycloak_openid_client_authorization_resource" "users" {
 
     scopes = [
         keycloak_openid_client_authorization_scope.create_scope.name,
+        keycloak_openid_client_authorization_scope.read_scope.name,
+        keycloak_openid_client_authorization_scope.update_scope.name,
         keycloak_openid_client_authorization_scope.delete_scope.name
     ]
 }
@@ -446,11 +448,11 @@ resource "keycloak_openid_client_role_policy" "only_app_users_and_app_admins_pol
 
 ## Add permissions for the authorization services for the DOS API client.
 
-# Add permission for creating and deleting users.
-resource "keycloak_openid_client_authorization_permission" "cd_users_permission" {
+# Add permission for creating and deleting users, and reading and updating user data.
+resource "keycloak_openid_client_authorization_permission" "crud_users_permission" {
     resource_server_id = keycloak_openid_client.dos_api_openid_client.resource_server_id
     realm_id           = keycloak_realm.dos_dev_realm.id
-    name               = "Create and delete users"
+    name               = "Create and delete users, and read and update user data"
     type               = "scope"
 
     policies = [
@@ -463,6 +465,8 @@ resource "keycloak_openid_client_authorization_permission" "cd_users_permission"
 
     scopes = [
         keycloak_openid_client_authorization_scope.create_scope.id,
+        keycloak_openid_client_authorization_scope.read_scope.id,
+        keycloak_openid_client_authorization_scope.update_scope.id,
         keycloak_openid_client_authorization_scope.delete_scope.id
     ]
 }


### PR DESCRIPTION
When switching to a different realm, the user IDs for clearance items need to be updated to use the IDs from that realm. This PR adds utility endpoints for that purpose.

Please see the individual commits for details.