### PR TITLE
Refactor session handling

### DIFF
--- a/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/BulkConclusionList.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/bulk_conclusions/BulkConclusionList.tsx
@@ -9,14 +9,12 @@ import {
     parseAsStringEnum,
     useQueryState,
 } from "nuqs";
-import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
 import { columns } from "@/components/clearance_library/bulk_conclusions/columns";
 import { DataTable } from "@/components/clearance_library/bulk_conclusions/DataTable";
 import { getErrorMessage } from "@/helpers/getErrorMessage";
 
 const BulkConclusionList = () => {
-    const user = useUser();
     const [pageSize] = useQueryState(
         "pageSize",
         parseAsInteger.withDefault(10),
@@ -45,14 +43,11 @@ const BulkConclusionList = () => {
         parseAsStringEnum(["asc", "desc"]).withDefault("desc"),
     );
 
-    const bcCntQuery = userHooks.useGetBulkConclusionsCount(
-        {
-            queries: {
-                purl: searchPurl !== null ? searchPurl : undefined,
-            },
+    const bcCntQuery = userHooks.useGetBulkConclusionsCount({
+        queries: {
+            purl: searchPurl !== null ? searchPurl : undefined,
         },
-        { enabled: !!user },
-    );
+    });
 
     const { data, isLoading, error } = userHooks.useGetBulkConclusions(
         {
@@ -64,7 +59,7 @@ const BulkConclusionList = () => {
                 purl: searchPurl !== null ? searchPurl : undefined,
             },
         },
-        { enabled: !!user && !!pageSize && !!pageIndex },
+        { enabled: !!pageSize && !!pageIndex },
     );
     if (isLoading) {
         return (

--- a/apps/clearance_ui/src/components/clearance_library/license_conclusions/LicenseConclusionList.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/license_conclusions/LicenseConclusionList.tsx
@@ -9,14 +9,12 @@ import {
     parseAsStringEnum,
     useQueryState,
 } from "nuqs";
-import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
 import { columns } from "@/components/clearance_library/license_conclusions/columns";
 import { DataTable } from "@/components/clearance_library/license_conclusions/DataTable";
 import { getErrorMessage } from "@/helpers/getErrorMessage";
 
 const LicenseConclusionList = () => {
-    const user = useUser();
     const [pageSize] = useQueryState(
         "pageSize",
         parseAsInteger.withDefault(10),
@@ -44,23 +42,20 @@ const LicenseConclusionList = () => {
         parseAsStringEnum(["asc", "desc"]).withDefault("desc"),
     );
 
-    const lcCntQuery = userHooks.useGetLicenseConclusionsCount(
-        {
-            queries: {
-                contextPurl: contextPurl !== null ? contextPurl : undefined,
-                /*
-                 * The initial idea of these queries was to fetch the license conclusions that are
-                 * not part of a bulk conclusion (and their count) by setting the bulkConclusionId to
-                 * null, but for some reason a parameter with null value is completely dropped from the
-                 * query, and in the lack of a better solution, a workaround with the parameter
-                 * hasBulkConclusion is used here.
-                 */
-                //bulkConclusionId: null,
-                hasBulkConclusionId: false,
-            },
+    const lcCntQuery = userHooks.useGetLicenseConclusionsCount({
+        queries: {
+            contextPurl: contextPurl !== null ? contextPurl : undefined,
+            /*
+             * The initial idea of these queries was to fetch the license conclusions that are
+             * not part of a bulk conclusion (and their count) by setting the bulkConclusionId to
+             * null, but for some reason a parameter with null value is completely dropped from the
+             * query, and in the lack of a better solution, a workaround with the parameter
+             * hasBulkConclusion is used here.
+             */
+            //bulkConclusionId: null,
+            hasBulkConclusionId: false,
         },
-        { enabled: !!user },
-    );
+    });
 
     const { data, isLoading, error } = userHooks.useGetLicenseConclusions(
         {
@@ -74,7 +69,7 @@ const LicenseConclusionList = () => {
                 hasBulkConclusionId: false,
             },
         },
-        { enabled: !!user && !!pageSize && !!pageIndex },
+        { enabled: !!pageSize && !!pageIndex },
     );
     if (isLoading) {
         return (

--- a/apps/clearance_ui/src/components/clearance_library/path_exclusions/PathExclusionList.tsx
+++ b/apps/clearance_ui/src/components/clearance_library/path_exclusions/PathExclusionList.tsx
@@ -9,14 +9,12 @@ import {
     parseAsStringEnum,
     useQueryState,
 } from "nuqs";
-import { useUser } from "@/hooks/useUser";
 import { userHooks } from "@/hooks/zodiosHooks";
 import { columns } from "@/components/clearance_library/path_exclusions/columns";
 import { DataTable } from "@/components/clearance_library/path_exclusions/DataTable";
 import { getErrorMessage } from "@/helpers/getErrorMessage";
 
 const PathExclusionList = () => {
-    const user = useUser();
     const [pageSize] = useQueryState(
         "pageSize",
         parseAsInteger.withDefault(10),
@@ -43,14 +41,11 @@ const PathExclusionList = () => {
         parseAsStringEnum(["asc", "desc"]).withDefault("desc"),
     );
 
-    const peCntQuery = userHooks.useGetPathExclusionsCount(
-        {
-            queries: {
-                purl: searchPurl !== null ? searchPurl : undefined,
-            },
+    const peCntQuery = userHooks.useGetPathExclusionsCount({
+        queries: {
+            purl: searchPurl !== null ? searchPurl : undefined,
         },
-        { enabled: !!user },
-    );
+    });
 
     const { data, isLoading, error } = userHooks.useGetPathExclusions(
         {
@@ -62,7 +57,7 @@ const PathExclusionList = () => {
                 purl: searchPurl !== null ? searchPurl : undefined,
             },
         },
-        { enabled: !!user && !!pageSize && !!pageIndex },
+        { enabled: !!pageSize && !!pageIndex },
     );
     if (isLoading) {
         return (

--- a/apps/clearance_ui/src/components/navigation/Navbar.tsx
+++ b/apps/clearance_ui/src/components/navigation/Navbar.tsx
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 import React from "react";
-import { useSession } from "next-auth/react";
 import { Fira_Code } from "next/font/google";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { PackageURL } from "packageurl-js";
+import { useUser } from "@/hooks/useUser";
 import { Label } from "@/components/ui/label";
 import CopyToClipboard from "@/components/common/CopyToClipboard";
 import { ModeToggle } from "@/components/common/ModeToggle";
@@ -23,7 +23,7 @@ const fira_code = Fira_Code({
 });
 
 const Navbar = () => {
-    const session = useSession();
+    const user = useUser();
     const router = useRouter();
     const { purl, path } = router.query;
     let mainPurl;
@@ -62,31 +62,23 @@ const Navbar = () => {
                         ()
                     </span>
                 </Link>
-                {session.status === "authenticated" &&
-                    !session.data.error &&
-                    mainPurl && (
+                {user && mainPurl && (
+                    <div className="flex-row items-center">
+                        <Label className="text-xs break-all">{mainPurl}</Label>
+                        <CopyToClipboard copyText={mainPurl} />
+                    </div>
+                )}
+                {user && path && (
+                    <>
+                        <Label className="pr-2 pl-1 text-lg font-semibold text-[#FF3366]">
+                            /
+                        </Label>
                         <div className="flex-row items-center">
-                            <Label className="text-xs break-all">
-                                {mainPurl}
-                            </Label>
-                            <CopyToClipboard copyText={mainPurl} />
+                            <Label className="text-xs break-all">{path}</Label>
+                            <CopyToClipboard copyText={path as string} />
                         </div>
-                    )}
-                {session.status === "authenticated" &&
-                    !session.data.error &&
-                    path && (
-                        <>
-                            <Label className="pr-2 pl-1 text-lg font-semibold text-[#FF3366]">
-                                /
-                            </Label>
-                            <div className="flex-row items-center">
-                                <Label className="text-xs break-all">
-                                    {path}
-                                </Label>
-                                <CopyToClipboard copyText={path as string} />
-                            </div>
-                        </>
-                    )}
+                    </>
+                )}
             </div>
             <div>
                 <UserMenuItem className="mr-1" />

--- a/apps/clearance_ui/src/components/package_library/PackageList.tsx
+++ b/apps/clearance_ui/src/components/package_library/PackageList.tsx
@@ -10,14 +10,12 @@ import {
     parseAsStringEnum,
     useQueryState,
 } from "nuqs";
-import { useUser } from "@/hooks/useUser";
 import { adminHooks } from "@/hooks/zodiosHooks";
 import { columns } from "@/components/package_library/columns";
 import { DataTable } from "@/components/package_library/DataTable";
 import { getErrorMessage } from "@/helpers/getErrorMessage";
 
 const PackageList = ({ pkgCnt }: { pkgCnt: number }) => {
-    const user = useUser();
     const [pageSize] = useQueryState(
         "pageSize",
         parseAsInteger.withDefault(10),
@@ -62,17 +60,12 @@ const PackageList = ({ pkgCnt }: { pkgCnt: number }) => {
                 name: name !== null ? name : undefined,
             },
         },
-        { enabled: !!user && !!pageSize && !!pageIndex },
+        { enabled: !!pageSize && !!pageIndex },
     );
 
-    const pkgCntQuery = adminHooks.useGetPackagesCount(
-        {
-            queries: { name: name !== null ? name : undefined },
-        },
-        { enabled: !!user },
-    );
-
-    if (!user) return null;
+    const pkgCntQuery = adminHooks.useGetPackagesCount({
+        queries: { name: name !== null ? name : undefined },
+    });
 
     return (
         <>

--- a/apps/clearance_ui/src/components/providers/TanstackProvider.tsx
+++ b/apps/clearance_ui/src/components/providers/TanstackProvider.tsx
@@ -3,11 +3,51 @@
 // SPDX-License-Identifier: MIT
 
 import { useState } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+    QueryCache,
+    QueryClient,
+    QueryClientProvider,
+} from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { isAxiosError } from "axios";
+import { signIn } from "next-auth/react";
+import { getAccessToken } from "@/lib/authTokenManager";
 
 const TanstackProvider = ({ children }: { children: React.ReactNode }) => {
-    const [queryClient] = useState(() => new QueryClient());
+    const [queryClient] = useState(
+        () =>
+            new QueryClient({
+                queryCache: new QueryCache({
+                    onError: async (error) => {
+                        if (
+                            isAxiosError(error) &&
+                            error.response?.status === 401
+                        ) {
+                            /*
+                             * Check if the session is not valid anymore by
+                             * attempting to call the userinfo endpoint.
+                             * This extra check should help mitigate possible
+                             * network issues that could be causing a temporary
+                             * 401 error.
+                             */
+
+                            const response = await fetch("/api/auth/userinfo", {
+                                headers: {
+                                    Authorization: `Bearer ${getAccessToken()}`,
+                                },
+                            });
+
+                            if (response.status === 401) {
+                                // Redirect to login page
+                                signIn("keycloak", {
+                                    callbackUrl: window.location.href,
+                                });
+                            }
+                        }
+                    },
+                }),
+            }),
+    );
     return (
         <QueryClientProvider client={queryClient}>
             {children}

--- a/apps/clearance_ui/src/components/user_management/UserDataForm.tsx
+++ b/apps/clearance_ui/src/components/user_management/UserDataForm.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { passwordStrength } from "check-password-strength";
 import { Check, Loader2, Pencil } from "lucide-react";
-import { signIn, useSession } from "next-auth/react";
+import { signIn } from "next-auth/react";
 import { useForm } from "react-hook-form";
 import { getUsernameSchema } from "validation-helpers";
 import z from "zod";
@@ -71,7 +71,6 @@ type PutUserDataType = z.infer<typeof userDataFormSchema>;
 
 const UserDataForm = () => {
     const user = useUser();
-    const session = useSession();
     const [editMode, setEditMode] = useState(false);
     const queryClient = useQueryClient();
 
@@ -97,17 +96,12 @@ const UserDataForm = () => {
                     error.response?.data?.message ===
                     "User with this username or email already exists"
                 ) {
-                    if (
-                        form.getValues("username") ===
-                        session.data?.user?.preferred_username
-                    ) {
+                    if (form.getValues("username") === user?.username) {
                         form.setError("email", {
                             type: "manual",
                             message: "Email already in use with another user",
                         });
-                    } else if (
-                        form.getValues("email") === session.data?.user?.email
-                    ) {
+                    } else if (form.getValues("email") === user?.email) {
                         form.setError("username", {
                             type: "manual",
                             message: "Username already in use",
@@ -137,9 +131,9 @@ const UserDataForm = () => {
         resolver: zodResolver(userDataFormSchema),
         values: {
             username: user?.username,
-            firstName: session.data?.user?.given_name || "",
-            lastName: session.data?.user?.family_name || "",
-            email: session.data?.user?.email || "",
+            firstName: user?.firstName || "",
+            lastName: user?.lastName || "",
+            email: user?.email || "",
             password: "",
             confirmPassword: "",
             role: user?.role,

--- a/apps/clearance_ui/src/hooks/useUser/index.ts
+++ b/apps/clearance_ui/src/hooks/useUser/index.ts
@@ -7,13 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import type { Permissions } from "validation-helpers";
 
-export type User = {
-    username: string;
-    role: string;
-    permissions: Permissions | null;
-};
-
-export const useUser: () => User | null = () => {
+export const useUser = () => {
     const session = useSession();
     const [permissions, setPermissions] = useState<Permissions | null>(null);
 

--- a/apps/clearance_ui/src/hooks/useUser/index.ts
+++ b/apps/clearance_ui/src/hooks/useUser/index.ts
@@ -65,6 +65,9 @@ export const useUser = () => {
     return session.status === "authenticated"
         ? {
               username: session.data.user.preferred_username,
+              email: session.data.user.email,
+              firstName: session.data.user.given_name,
+              lastName: session.data.user.family_name,
               role:
                   session.data.user.realm_access.roles?.find((role) =>
                       role.startsWith("app-"),

--- a/apps/clearance_ui/src/pages/admin/users/index.tsx
+++ b/apps/clearance_ui/src/pages/admin/users/index.tsx
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 import { useEffect } from "react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
 import MultiSection from "@/components/common/MultiSection";
@@ -11,11 +10,10 @@ import RegisterUser from "@/components/user_management/RegisterUser";
 import { hasPermission } from "@/helpers/hasPermission";
 
 export default function UserManagement() {
-    const session = useSession({
+    const router = useRouter();
+    const user = useUser({
         required: true,
     });
-    const router = useRouter();
-    const user = useUser();
 
     useEffect(() => {
         if (
@@ -26,14 +24,6 @@ export default function UserManagement() {
             router.push("/403");
         }
     }, [user, router]);
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     return (
         <>

--- a/apps/clearance_ui/src/pages/api/auth/userinfo.ts
+++ b/apps/clearance_ui/src/pages/api/auth/userinfo.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 Double Open Oy
+//
+// SPDX-License-Identifier: MIT
+
+import { Zodios } from "@zodios/core";
+import { isAxiosError } from "axios";
+import { authConfig } from "common-helpers";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { keycloakAPI } from "validation-helpers";
+
+const kcClient = new Zodios(authConfig.url, keycloakAPI);
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse,
+) {
+    try {
+        const response = await kcClient.GetUserInfo({
+            params: {
+                realm: authConfig.realm,
+            },
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                Authorization: req.headers.authorization,
+            },
+        });
+
+        return res.status(200).json({ response });
+    } catch (error) {
+        if (isAxiosError(error)) {
+            res.status(error.response?.status || 500).json(
+                error.response?.data || { message: error.message },
+            );
+        } else {
+            return res.status(500).json({ message: "Internal server error" });
+        }
+    }
+}

--- a/apps/clearance_ui/src/pages/clearances/index.tsx
+++ b/apps/clearance_ui/src/pages/clearances/index.tsx
@@ -35,7 +35,7 @@ export default function ClearanceLibrary() {
 
     return (
         <div className="flex h-full flex-col p-2">
-            {user && (
+            {user ? (
                 <>
                     <div className="m-1 flex-none rounded-md shadow-sm">
                         <Card>
@@ -96,8 +96,7 @@ export default function ClearanceLibrary() {
                         </Tabs>
                     </div>
                 </>
-            )}
-            {session.status === "loading" && (
+            ) : (
                 <div className="flex h-full items-center justify-center">
                     <Loader2 className="mr-2 h-16 w-16 animate-spin" />
                 </div>

--- a/apps/clearance_ui/src/pages/clearances/index.tsx
+++ b/apps/clearance_ui/src/pages/clearances/index.tsx
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { parseAsString, useQueryState } from "nuqs";
 import { useUser } from "@/hooks/useUser";
@@ -20,18 +18,9 @@ export default function ClearanceLibrary() {
         "tab",
         parseAsString.withDefault("license_conclusions"),
     );
-    const user = useUser();
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     return (
         <div className="flex h-full flex-col p-2">

--- a/apps/clearance_ui/src/pages/index.tsx
+++ b/apps/clearance_ui/src/pages/index.tsx
@@ -2,18 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useEffect } from "react";
-import { signOut, useSession } from "next-auth/react";
-
 export default function Home() {
-    const session = useSession();
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        }
-    }, [session.data?.error]);
-
     return (
         <main className="min-h-full">
             <div className="flex flex-col items-center justify-center py-6">

--- a/apps/clearance_ui/src/pages/packages/[purl]/bulk_conclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/bulk_conclusions.tsx
@@ -5,12 +5,14 @@
 import React, { useEffect } from "react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
+import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
 import BulkConclusionWrapper from "@/components/main_ui/package_bulk_conclusions/BulkConclusionWrapper";
 
 const BulkConclusions = () => {
     const router = useRouter();
     const purl = router.query.purl;
+    const user = useUser();
 
     const session = useSession({
         required: true,
@@ -24,7 +26,7 @@ const BulkConclusions = () => {
         }
     }, [session.data?.error]);
 
-    if (!purl || session.status === "loading") {
+    if (!purl || !user) {
         return <div>Loading...</div>;
     }
     if (typeof purl !== "string") {

--- a/apps/clearance_ui/src/pages/packages/[purl]/bulk_conclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/bulk_conclusions.tsx
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useEffect } from "react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
@@ -12,19 +10,9 @@ import BulkConclusionWrapper from "@/components/main_ui/package_bulk_conclusions
 const BulkConclusions = () => {
     const router = useRouter();
     const purl = router.query.purl;
-    const user = useUser();
-
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     if (!purl || !user) {
         return <div>Loading...</div>;

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -7,6 +7,7 @@ import { signIn, signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { PackageURL } from "packageurl-js";
+import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
 import { getProvenanceType } from "@/helpers/getProvenanceType";
 import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
@@ -14,6 +15,7 @@ import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
 const Details = () => {
     const router = useRouter();
     const purl = router.query.purl;
+    const user = useUser();
     const session = useSession({
         required: true,
     });
@@ -26,7 +28,7 @@ const Details = () => {
         }
     }, [session.data?.error]);
 
-    if (!purl || session.status === "loading") {
+    if (!purl || !user) {
         return <div>Loading...</div>;
     }
     if (typeof purl !== "string") {

--- a/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/details.tsx
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useEffect } from "react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { PackageURL } from "packageurl-js";
@@ -15,18 +13,9 @@ import { parsePurlAndQualifiers } from "@/helpers/parsePurlAndQualifiers";
 const Details = () => {
     const router = useRouter();
     const purl = router.query.purl;
-    const user = useUser();
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     if (!purl || !user) {
         return <div>Loading...</div>;

--- a/apps/clearance_ui/src/pages/packages/[purl]/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/index.tsx
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
@@ -28,19 +26,9 @@ export default function Package() {
     setPurl(purl as string);
     setPath("");
 
-    const user = useUser();
-
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     return (
         <div className="h-full">

--- a/apps/clearance_ui/src/pages/packages/[purl]/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/index.tsx
@@ -7,6 +7,7 @@ import { Loader2 } from "lucide-react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
+import { useUser } from "@/hooks/useUser";
 import useMainUiStore from "@/store/mainui.store";
 import useSettingsStore from "@/store/settings.store";
 
@@ -27,6 +28,8 @@ export default function Package() {
     setPurl(purl as string);
     setPath("");
 
+    const user = useUser();
+
     const session = useSession({
         required: true,
     });
@@ -41,15 +44,14 @@ export default function Package() {
 
     return (
         <div className="h-full">
-            {session.status === "authenticated" && purl && (
+            {user && purl ? (
                 <MainUI
                     purl={purl.toString().replace(/\/@/g, "/%40")}
                     path={undefined}
                     defaultMainWidths={mainWidths}
                     defaultClearanceHeights={clearanceHeights}
                 />
-            )}
-            {session.status === "loading" && (
+            ) : (
                 <div className="flex h-full items-center justify-center">
                     <Loader2 className="mr-2 h-16 w-16 animate-spin" />
                 </div>

--- a/apps/clearance_ui/src/pages/packages/[purl]/license_conclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/license_conclusions.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect } from "react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
+import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
 import LicenseConclusionWrapper from "@/components/main_ui/package_license_conclusions/LicenseConclusionWrapper";
 
@@ -14,6 +15,7 @@ const LicenseConclusions = () => {
     const session = useSession({
         required: true,
     });
+    const user = useUser();
 
     useEffect(() => {
         if (session.data?.error === "SessionNotActiveError") {
@@ -23,7 +25,7 @@ const LicenseConclusions = () => {
         }
     }, [session.data?.error]);
 
-    if (!purl || session.status === "loading") {
+    if (!purl || !user) {
         return <div>Loading...</div>;
     }
     if (typeof purl !== "string") {

--- a/apps/clearance_ui/src/pages/packages/[purl]/license_conclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/license_conclusions.tsx
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useEffect } from "react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
@@ -12,18 +10,9 @@ import LicenseConclusionWrapper from "@/components/main_ui/package_license_concl
 const LicenseConclusions = () => {
     const router = useRouter();
     const purl = router.query.purl;
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
-    const user = useUser();
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     if (!purl || !user) {
         return <div>Loading...</div>;

--- a/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect } from "react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
+import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
 import PathExclusionWrapper from "@/components/main_ui/package_path_exclusions/PathExclusionWrapper";
 
@@ -14,6 +15,7 @@ const PathExclusions = () => {
     const session = useSession({
         required: true,
     });
+    const user = useUser();
 
     useEffect(() => {
         if (session.data?.error === "SessionNotActiveError") {
@@ -23,7 +25,7 @@ const PathExclusions = () => {
         }
     }, [session.data?.error]);
 
-    if (!purl || session.status === "loading") {
+    if (!purl || !user) {
         return <div>Loading...</div>;
     }
     if (typeof purl !== "string") {

--- a/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/path_exclusions.tsx
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useEffect } from "react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
 import ClearanceToolbar from "@/components/main_ui/ClearanceToolbar";
@@ -12,18 +10,9 @@ import PathExclusionWrapper from "@/components/main_ui/package_path_exclusions/P
 const PathExclusions = () => {
     const router = useRouter();
     const purl = router.query.purl;
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
-    const user = useUser();
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     if (!purl || !user) {
         return <div>Loading...</div>;

--- a/apps/clearance_ui/src/pages/packages/[purl]/tree/[path].tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/tree/[path].tsx
@@ -52,15 +52,14 @@ export default function PackageAndFile() {
 
     return (
         <div className="h-full">
-            {user && purl && path && (
+            {user && purl && path ? (
                 <MainUI
                     purl={purl.toString().replace(/\/@/g, "/%40")}
                     path={path.toString()}
                     defaultMainWidths={mainWidths}
                     defaultClearanceHeights={clearanceHeights}
                 />
-            )}
-            {session.status === "loading" && (
+            ) : (
                 <div className="flex h-full items-center justify-center">
                     <Loader2 className="mr-2 h-16 w-16 animate-spin" />
                 </div>

--- a/apps/clearance_ui/src/pages/packages/[purl]/tree/[path].tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/tree/[path].tsx
@@ -4,7 +4,6 @@
 
 import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
@@ -24,8 +23,7 @@ export default function PackageAndFile() {
     const { purl, path } = router.query;
     const setPurl = useMainUiStore((state) => state.setPurl);
     const setPath = useMainUiStore((state) => state.setPath);
-    const user = useUser();
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
 
@@ -41,14 +39,6 @@ export default function PackageAndFile() {
         setPurl(purl);
         setPath(path);
     }, [purl, path]);
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     return (
         <div className="h-full">

--- a/apps/clearance_ui/src/pages/packages/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/index.tsx
@@ -98,7 +98,7 @@ export default function PackageLibrary() {
                     </div>
                 </>
             )}
-            {session.status === "loading" && (
+            {!user && (
                 <div className="flex h-full items-center justify-center">
                     <Loader2 className="mr-2 h-16 w-16 animate-spin" />
                 </div>

--- a/apps/clearance_ui/src/pages/packages/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/index.tsx
@@ -4,7 +4,6 @@
 
 import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useUser } from "@/hooks/useUser";
 import { adminHooks } from "@/hooks/zodiosHooks";
@@ -14,11 +13,10 @@ import { getErrorMessage } from "@/helpers/getErrorMessage";
 import { hasPermission } from "@/helpers/hasPermission";
 
 export default function PackageLibrary() {
-    const session = useSession({
+    const router = useRouter();
+    const user = useUser({
         required: true,
     });
-    const router = useRouter();
-    const user = useUser();
 
     useEffect(() => {
         if (
@@ -37,14 +35,6 @@ export default function PackageLibrary() {
     } = adminHooks.useGetPackagesCount(undefined, {
         enabled: !!user,
     });
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     return (
         <div className="flex h-full flex-col p-2">

--- a/apps/clearance_ui/src/pages/packages/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/index.tsx
@@ -35,7 +35,7 @@ export default function PackageLibrary() {
         isLoading: pkgCntLoading,
         error: pkgCntError,
     } = adminHooks.useGetPackagesCount(undefined, {
-        enabled: session.status === "authenticated",
+        enabled: !!user,
     });
 
     useEffect(() => {

--- a/apps/clearance_ui/src/pages/packages/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/index.tsx
@@ -34,16 +34,9 @@ export default function PackageLibrary() {
         data: pkgCntData,
         isLoading: pkgCntLoading,
         error: pkgCntError,
-    } = adminHooks.useGetPackagesCount(
-        {
-            headers: {
-                Authorization: `Bearer ${session?.data?.accessToken}`,
-            },
-        },
-        {
-            enabled: session.status === "authenticated",
-        },
-    );
+    } = adminHooks.useGetPackagesCount(undefined, {
+        enabled: session.status === "authenticated",
+    });
 
     useEffect(() => {
         if (session.data?.error === "SessionNotActiveError") {

--- a/apps/clearance_ui/src/pages/settings/index.tsx
+++ b/apps/clearance_ui/src/pages/settings/index.tsx
@@ -2,17 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useUser } from "@/hooks/useUser";
 import MultiSection from "@/components/common/MultiSection";
 import TokenDialog from "@/components/user_management/TokenDialog";
 import UserDataForm from "@/components/user_management/UserDataForm";
 
 export default function Settings() {
-    const user = useUser();
-    const session = useSession({
+    const user = useUser({
         required: true,
     });
 
@@ -35,14 +32,6 @@ export default function Settings() {
             </>
         );
     }
-
-    useEffect(() => {
-        if (session.data?.error === "SessionNotActiveError") {
-            signOut();
-        } else if (session.data?.error !== undefined) {
-            signIn("keycloak");
-        }
-    }, [session.data?.error]);
 
     return (
         <>

--- a/apps/clearance_ui/src/pages/settings/index.tsx
+++ b/apps/clearance_ui/src/pages/settings/index.tsx
@@ -17,16 +17,7 @@ export default function Settings() {
     });
 
     function Profile() {
-        return (
-            <>
-                {user && <UserDataForm />}
-                {session.status === "loading" && (
-                    <div className="flex h-full items-center justify-center">
-                        <Loader2 className="mr-2 h-16 w-16 animate-spin" />
-                    </div>
-                )}
-            </>
-        );
+        return <UserDataForm />;
     }
 
     function Tokens() {
@@ -40,12 +31,7 @@ export default function Settings() {
                     Please note that your previous token will be invalidated
                     when you create a new one.
                 </p>
-                {user && <TokenDialog />}
-                {session.status === "loading" && (
-                    <div className="flex h-full items-center justify-center">
-                        <Loader2 className="mr-2 h-16 w-16 animate-spin" />
-                    </div>
-                )}
+                <TokenDialog />
             </>
         );
     }
@@ -60,7 +46,7 @@ export default function Settings() {
 
     return (
         <>
-            {user && (
+            {user ? (
                 <MultiSection
                     title="Settings"
                     defaultSection="profile"
@@ -79,6 +65,10 @@ export default function Settings() {
                         },
                     ]}
                 />
+            ) : (
+                <div className="flex h-full items-center justify-center">
+                    <Loader2 className="mr-2 h-16 w-16 animate-spin" />
+                </div>
             )}
         </>
     );

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -20086,6 +20086,109 @@ declare const keycloakAPI: [
             },
         ];
     },
+    {
+        method: "get";
+        path: "/realms/:realm/protocol/openid-connect/userinfo";
+        description: "Get user info";
+        alias: "GetUserInfo";
+        response: zod.ZodObject<
+            {
+                sub: zod.ZodString;
+                resource_access: zod.ZodRecord<
+                    zod.ZodString,
+                    zod.ZodObject<
+                        {
+                            roles: zod.ZodArray<zod.ZodString, "many">;
+                        },
+                        "strip",
+                        zod.ZodTypeAny,
+                        {
+                            roles: string[];
+                        },
+                        {
+                            roles: string[];
+                        }
+                    >
+                >;
+                email_verified: zod.ZodBoolean;
+                realm_access: zod.ZodObject<
+                    {
+                        roles: zod.ZodArray<zod.ZodString, "many">;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        roles: string[];
+                    },
+                    {
+                        roles: string[];
+                    }
+                >;
+                name: zod.ZodString;
+                preferred_username: zod.ZodString;
+                given_name: zod.ZodString;
+                family_name: zod.ZodString;
+                email: zod.ZodString;
+            },
+            "strip",
+            zod.ZodTypeAny,
+            {
+                email: string;
+                name: string;
+                sub: string;
+                resource_access: Record<
+                    string,
+                    {
+                        roles: string[];
+                    }
+                >;
+                email_verified: boolean;
+                realm_access: {
+                    roles: string[];
+                };
+                preferred_username: string;
+                given_name: string;
+                family_name: string;
+            },
+            {
+                email: string;
+                name: string;
+                sub: string;
+                resource_access: Record<
+                    string,
+                    {
+                        roles: string[];
+                    }
+                >;
+                email_verified: boolean;
+                realm_access: {
+                    roles: string[];
+                };
+                preferred_username: string;
+                given_name: string;
+                family_name: string;
+            }
+        >;
+        errors: [
+            {
+                status: 400;
+                description: "Bad request";
+                schema: zod.ZodObject<
+                    {
+                        error: zod.ZodString;
+                    },
+                    "strip",
+                    zod.ZodTypeAny,
+                    {
+                        error: string;
+                    },
+                    {
+                        error: string;
+                    }
+                >;
+            },
+        ];
+    },
 ];
 
 declare const TokenResponse: z.ZodObject<

--- a/packages/validation-helpers/src/kc/api.ts
+++ b/packages/validation-helpers/src/kc/api.ts
@@ -218,4 +218,12 @@ export const keycloakAPI = makeApi([
         response: schemas.GetUserByIdResponse,
         errors,
     },
+    {
+        method: "get",
+        path: "/realms/:realm/protocol/openid-connect/userinfo",
+        description: "Get user info",
+        alias: "GetUserInfo",
+        response: schemas.GetUserInfoResponse,
+        errors,
+    },
 ]);

--- a/packages/validation-helpers/src/kc/schemas.ts
+++ b/packages/validation-helpers/src/kc/schemas.ts
@@ -143,3 +143,22 @@ export const ResetUserPasswordReq = z.object({
 });
 
 export const GetUserByIdResponse = UserRepresentation;
+
+export const GetUserInfoResponse = z.object({
+    sub: z.string(),
+    resource_access: z.record(
+        z.string(),
+        z.object({
+            roles: z.array(z.string()),
+        }),
+    ),
+    email_verified: z.boolean(),
+    realm_access: z.object({
+        roles: z.array(z.string()),
+    }),
+    name: z.string(),
+    preferred_username: z.string(),
+    given_name: z.string(),
+    family_name: z.string(),
+    email: z.string(),
+});


### PR DESCRIPTION
This PR refactors the session handling so that it is centralized as much as possible to the `useUser` hook. This will help unify the handling, and also make it easier to possibly test a different authentication tool than NextAuth. This PR also adds a fix for a specific situation when the session is killed elsewhere, and NextAuth doesn't catch this until it tries to renew the token.

Please see the individual commits for details.