### PR TITLE
fix(ui): Remove character replacement

### DIFF
--- a/apps/clearance_ui/src/pages/packages/[purl]/index.tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/index.tsx
@@ -34,7 +34,7 @@ export default function Package() {
         <div className="h-full">
             {user && purl ? (
                 <MainUI
-                    purl={purl.toString().replace(/\/@/g, "/%40")}
+                    purl={purl.toString()}
                     path={undefined}
                     defaultMainWidths={mainWidths}
                     defaultClearanceHeights={clearanceHeights}

--- a/apps/clearance_ui/src/pages/packages/[purl]/tree/[path].tsx
+++ b/apps/clearance_ui/src/pages/packages/[purl]/tree/[path].tsx
@@ -44,7 +44,7 @@ export default function PackageAndFile() {
         <div className="h-full">
             {user && purl && path ? (
                 <MainUI
-                    purl={purl.toString().replace(/\/@/g, "/%40")}
+                    purl={purl.toString()}
                     path={path.toString()}
                     defaultMainWidths={mainWidths}
                     defaultClearanceHeights={clearanceHeights}


### PR DESCRIPTION
Early on, there seems to have been a problem with some purls that have the `@` character in the namespace name, and a fix for that has been added in commit https://github.com/doubleopen-project/dos/commit/0b1ab03c1a9c66ce82b3ff0efe2bcb3e93958dd8. However, it seems that the issue has later been properly fixed in https://github.com/doubleopen-project/dos/commit/ed597352a326fbd7d156b55da79436f3e20b63ae#diff-3d70548174639bccd44afe17abd6df0f10bc7c81f07d40a2da49a477c4c54494R5-R20, so there's no need for this character replacement anymore. Removing the replacement will fix an issue with some of the packages not loading properly in the UI.