### PR TITLE
refactor(api): Remove `fetchConcluded` option

### DIFF
--- a/apps/api/src/helpers/db_operations.ts
+++ b/apps/api/src/helpers/db_operations.ts
@@ -24,10 +24,7 @@ log.setLevel(logLevel);
 // ------------------------- Database operations -------------------------
 
 // Get scan results for package
-export const getScanResults = async (
-    purl: string,
-    options: { fetchConcluded?: boolean },
-) => {
+export const getScanResults = async (purl: string) => {
     const queriedScanResults = await dbQueries.getPackageScanResults(purl);
 
     if (queriedScanResults) {
@@ -36,30 +33,7 @@ export const getScanResults = async (
         const issues = [];
 
         for (const filetree of queriedScanResults) {
-            if (
-                options.fetchConcluded &&
-                filetree.file.licenseConclusions.length > 0
-            ) {
-                for (const licenseConclusion of filetree.file
-                    .licenseConclusions) {
-                    if (
-                        !licenseConclusion.local ||
-                        (licenseConclusion.local &&
-                            licenseConclusion.contextPurl === purl)
-                    ) {
-                        licenses.push({
-                            license:
-                                licenseConclusion.concludedLicenseExpressionSPDX,
-                            location: {
-                                path: filetree.path,
-                                start_line: undefined,
-                                end_line: undefined,
-                            },
-                            score: undefined,
-                        });
-                    }
-                }
-            } else if (filetree.file.licenseFindings.length > 0) {
+            if (filetree.file.licenseFindings.length > 0) {
                 let startLine = 0;
                 let endLine = 0;
                 let scoreSum = 0;

--- a/apps/api/src/helpers/db_queries.ts
+++ b/apps/api/src/helpers/db_queries.ts
@@ -2120,13 +2120,6 @@ export const getPackageScanResults = async (purl: string) => {
                                     },
                                 },
                             },
-                            licenseConclusions: {
-                                select: {
-                                    concludedLicenseExpressionSPDX: true,
-                                    local: true,
-                                    contextPurl: true,
-                                },
-                            },
                             copyrightFindings: {
                                 select: {
                                     copyright: true,

--- a/apps/api/src/routes/scanner_router.ts
+++ b/apps/api/src/routes/scanner_router.ts
@@ -62,8 +62,6 @@ scannerRouter.post(
                     reqPurls.join(", "),
             );
 
-            const options = req.body.options || {};
-
             const packages = await dbQueries.findPackagesByPurls(reqPurls);
 
             if (packages.length === 0) {
@@ -130,7 +128,6 @@ scannerRouter.post(
                     // The results will be the same for all packages, so we can just get the results for the first one
                     const results = await dbOperations.getScanResults(
                         scannedPackages[0].purl,
-                        options,
                     );
 
                     if (scannedPackages.length < reqPackages.length) {

--- a/packages/validation-helpers/index.d.ts
+++ b/packages/validation-helpers/index.d.ts
@@ -2109,43 +2109,14 @@ declare const scannerAPI: [
                                     >,
                                     "many"
                                 >;
-                                options: zod.ZodOptional<
-                                    zod.ZodObject<
-                                        {
-                                            fetchConcluded: zod.ZodOptional<zod.ZodBoolean>;
-                                        },
-                                        "strip",
-                                        zod.ZodTypeAny,
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        },
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        }
-                                    >
-                                >;
                             },
                             "strip",
                             zod.ZodTypeAny,
                             {
                                 purls: string[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             },
                             {
                                 purls: string[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             }
                         >,
                         zod.ZodObject<
@@ -2177,25 +2148,6 @@ declare const scannerAPI: [
                                     >,
                                     "many"
                                 >;
-                                options: zod.ZodOptional<
-                                    zod.ZodObject<
-                                        {
-                                            fetchConcluded: zod.ZodOptional<zod.ZodBoolean>;
-                                        },
-                                        "strip",
-                                        zod.ZodTypeAny,
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        },
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        }
-                                    >
-                                >;
                             },
                             "strip",
                             zod.ZodTypeAny,
@@ -2206,11 +2158,6 @@ declare const scannerAPI: [
                                         | string
                                         | null;
                                 }[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             },
                             {
                                 packages: {
@@ -2219,11 +2166,6 @@ declare const scannerAPI: [
                                         | string
                                         | null;
                                 }[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             }
                         >,
                     ]
@@ -9955,43 +9897,14 @@ declare const dosAPI: [
                                     >,
                                     "many"
                                 >;
-                                options: zod.ZodOptional<
-                                    zod.ZodObject<
-                                        {
-                                            fetchConcluded: zod.ZodOptional<zod.ZodBoolean>;
-                                        },
-                                        "strip",
-                                        zod.ZodTypeAny,
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        },
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        }
-                                    >
-                                >;
                             },
                             "strip",
                             zod.ZodTypeAny,
                             {
                                 purls: string[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             },
                             {
                                 purls: string[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             }
                         >,
                         zod.ZodObject<
@@ -10023,25 +9936,6 @@ declare const dosAPI: [
                                     >,
                                     "many"
                                 >;
-                                options: zod.ZodOptional<
-                                    zod.ZodObject<
-                                        {
-                                            fetchConcluded: zod.ZodOptional<zod.ZodBoolean>;
-                                        },
-                                        "strip",
-                                        zod.ZodTypeAny,
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        },
-                                        {
-                                            fetchConcluded?:
-                                                | boolean
-                                                | undefined;
-                                        }
-                                    >
-                                >;
                             },
                             "strip",
                             zod.ZodTypeAny,
@@ -10052,11 +9946,6 @@ declare const dosAPI: [
                                         | string
                                         | null;
                                 }[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             },
                             {
                                 packages: {
@@ -10065,11 +9954,6 @@ declare const dosAPI: [
                                         | string
                                         | null;
                                 }[];
-                                options?:
-                                    | {
-                                          fetchConcluded?: boolean | undefined;
-                                      }
-                                    | undefined;
                             }
                         >,
                     ]

--- a/packages/validation-helpers/src/api/apis/scanner.ts
+++ b/packages/validation-helpers/src/api/apis/scanner.ts
@@ -20,8 +20,7 @@ export const scannerAPI = makeApi([
         path: "/scan-results",
         description:
             "Get scan results for specified purl(s). Give multiple purls in the case where these purls are all part of the same source." +
-            " <ul><li>If only some of the purls are found in the database, bookmarks for the remaining ones will be made pointing to the same source files.</li>" +
-            "<li>If fetchConcluded is set to true, also human concluded licenses will be fetched from the license database and included in the results.</li></ul> ",
+            " If only some of the purls are found in the database, bookmarks for the remaining ones will be made pointing to the same source files.",
         parameters: [
             {
                 name: "body",

--- a/packages/validation-helpers/src/api/schemas/scanner_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/scanner_schemas.ts
@@ -19,11 +19,6 @@ export const PostScanResultsReq = z.union([
         purls: z
             .array(purlSchema(true))
             .min(1, "At least one purl is required"),
-        options: z
-            .object({
-                fetchConcluded: z.boolean().optional(),
-            })
-            .optional(),
     }),
     z.object({
         packages: z
@@ -34,11 +29,6 @@ export const PostScanResultsReq = z.union([
                 }),
             )
             .min(1, "At least one package is required"),
-        options: z
-            .object({
-                fetchConcluded: z.boolean().optional(),
-            })
-            .optional(),
     }),
 ]);
 


### PR DESCRIPTION
In anticipation of allowing users to create their own clearances and changes coming to which license conclusions will be returned in requests (based on an organization ID), the `fetchConcluded` option is removed from the scan results endpoint to reduce maintenance efforts.