### PR TITLE
ci(github): Add docker build task in Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,6 +30,8 @@ jobs:
               run: npm i --workspace packages/database
             - name: Run prisma generate
               run: npm run db:generate
+            - name: Build images
+              run: docker compose build
             - name: Start the testing environment
               run: docker compose up api clearance-ui scanner-worker createbuckets -d
             - name: Seed the database and populate the spaces bucket


### PR DESCRIPTION
The services defined with the `depends_on` attribute in the Docker Compose file used to be built automatically in the GitHub actions. However, this behavior seems to have changed, so add a task for building all the images before the services are started, so that the services that a service depends on are properly started.

This should fix the Playwright test issues for the other dependency updates, except for the `@hookform/resolvers` https://github.com/doubleopen-project/dos/pull/1288, which has a separate issue with `zod`.