### PR TITLE
ci(renovate): Pin @hookform/resolvers to version 5.1.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,10 @@
             "allowedVersions": "4.x"
         },
         {
+            "matchPackageNames": ["@hookform/resolvers"],
+            "allowedVersions": "5.1.0"
+        },
+        {
             "matchPackageNames": ["packageurl-js"],
             "allowedVersions": "1.2.1"
         },


### PR DESCRIPTION
The later versions of @hookform/resolvers require zod version 3.25.0 or higher, and due to Zodios zod needs to be kept in version 3.22.4.