### PR TITLE
ci(github): Enable Corepack in all workflows

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -28,6 +28,9 @@ jobs:
                   node-version: 22.17.1
                   cache: "npm"
 
+            - name: Enable Corepack
+              run: npm install corepack@latest && corepack enable
+
             - name: Install dependencies
               run: npm ci
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -24,6 +24,8 @@ jobs:
               with:
                   node-version: 22.17.1
                   cache: "npm"
+            - name: Enable Corepack
+              run: npm install corepack@latest && corepack enable
             - name: Install dependencies
               run: |-
                   npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,6 +24,8 @@ jobs:
               with:
                   node-version: 22.17.1
                   cache: "npm"
+            - name: Enable Corepack
+              run: npm install corepack@latest && corepack enable
             - name: Install dependencies for root
               run: npm i --workspaces=false
             - name: Install dependencies for the database package

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -28,6 +28,9 @@ jobs:
                   node-version: 22.17.1
                   cache: "npm"
 
+            - name: Enable Corepack
+              run: npm install corepack@latest && corepack enable
+
             - name: Install dependencies
               run: npm ci
 


### PR DESCRIPTION
Note that `actions/setup-node` itself still has no Corepack support [1].

[1]: https://github.com/actions/setup-node/issues/531