### PR TITLE
build(npm): Fixup the lockfile to hard-code the TypeScript version again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
                 "mocha": "11.7.1",
                 "tsconfig": "*",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "apps/api/node_modules/packageurl-js": {
@@ -275,7 +275,7 @@
                 "tailwindcss": "^4.0.0",
                 "ts-jest": "29.4.0",
                 "ts-node": "10.9.2",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "apps/clearance_ui/node_modules/packageurl-js": {
@@ -311,7 +311,7 @@
                 "dotenv-cli": "10.0.0",
                 "tsconfig": "*",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "apps/scanner_worker/node_modules/source-map": {
@@ -4199,6 +4199,61 @@
             "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.5.tgz",
             "integrity": "sha512-ruM+q2SCOVCepUiERoxOmZY9ZVoecR3gcXNwCYZRvQQWRjhOiPJGmQ2fAiLR6YKWXcSAh7G79KEFxN3rwhs4LQ==",
             "license": "MIT"
+        },
+        "node_modules/@next/eslint-plugin-next": {
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.31.tgz",
+            "integrity": "sha512-ouaB+l8Cr/uzGxoGHUvd01OnfFTM8qM81Crw1AG0xoWDRN0DKLXyTWVe0FdAOHVBpGuXB87aufdRmrwzZDArIw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "glob": "10.3.10"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/glob": {
+            "version": "10.3.10",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.3.5",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/@next/swc-darwin-arm64": {
             "version": "15.4.5",
@@ -21652,7 +21707,7 @@
                 "chai": "5.2.1",
                 "mocha": "11.7.1",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "packages/common-helpers/node_modules/source-map": {
@@ -21779,7 +21834,7 @@
                 "ts-node": "10.9.2",
                 "tsconfig": "*",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "packages/database/node_modules/source-map": {
@@ -22514,7 +22569,7 @@
                 "mocha": "11.7.1",
                 "tsconfig": "*",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "packages/s3-helpers/node_modules/source-map": {
@@ -22638,7 +22693,7 @@
                 "jest": "^30.0.0",
                 "tsconfig": "*",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "packages/spdx-validation/node_modules/source-map": {
@@ -22769,7 +22824,7 @@
                 "jest": "^30.0.0",
                 "ts-jest": "^29.2.5",
                 "tsup": "8.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "5.9.2"
             }
         },
         "packages/validation-helpers/node_modules/packageurl-js": {


### PR DESCRIPTION
This should avoid `npm install` to modify the lockfile.