### PR TITLE
chore: Rename `scannerVersion` to `scannerInfo`

### DIFF
--- a/apps/api/src/routes/scanner_router.ts
+++ b/apps/api/src/routes/scanner_router.ts
@@ -44,7 +44,7 @@ scannerRouter.get("/health", async (req, res) => {
 scannerRouter.get("/versions", async (req, res) => {
     res.status(200).json({
         dosVersion: "1.0.0",
-        scannerVersion: {
+        scannerInfo: {
             name: "scancode-toolkit",
             version: __SCANCODE_VERSION__,
         },

--- a/apps/api/tests/e2e/scanner_router.spec.ts
+++ b/apps/api/tests/e2e/scanner_router.spec.ts
@@ -284,8 +284,8 @@ test.describe("GET /versions should", () => {
         const body = await res.json();
 
         expect(body.dosVersion).toBe("1.0.0");
-        expect(body.scannerVersion.name).toBe("scancode-toolkit");
-        expect(body.scannerVersion.version).toMatch(/^\d+\.\d+\.\d+$/);
+        expect(body.scannerInfo.name).toBe("scancode-toolkit");
+        expect(body.scannerInfo.version).toMatch(/^\d+\.\d+\.\d+$/);
     });
 });
 

--- a/packages/validation-helpers/src/api/schemas/scanner_schemas.ts
+++ b/packages/validation-helpers/src/api/schemas/scanner_schemas.ts
@@ -16,7 +16,7 @@ export const GetHealthRes = z.object({
 
 export const GetVersionsRes = z.object({
     dosVersion: z.string(),
-    scannerVersion: z.object({
+    scannerInfo: z.object({
         name: z.string(),
         version: z.string(),
     }),


### PR DESCRIPTION
This contains more than just the version.