### PR TITLE
fix: add version field to internal workspace packages to enable ORT analyzer

### DIFF
--- a/packages/common-helpers/package.json
+++ b/packages/common-helpers/package.json
@@ -1,5 +1,6 @@
 {
     "name": "common-helpers",
+    "version": "0.0.0",
     "main": "./dist/src/index.js",
     "module": "./dist/src/index.mjs",
     "types": "./dist/src/index.d.ts",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,5 +1,6 @@
 {
     "name": "database",
+    "version": "0.0.0",
     "license": "MIT",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",

--- a/packages/s3-helpers/package.json
+++ b/packages/s3-helpers/package.json
@@ -1,5 +1,6 @@
 {
     "name": "s3-helpers",
+    "version": "0.0.0",
     "main": "./dist/src/index.js",
     "module": "./dist/src/index.mjs",
     "types": "./dist/src/index.d.ts",

--- a/packages/spdx-validation/package.json
+++ b/packages/spdx-validation/package.json
@@ -1,5 +1,6 @@
 {
     "name": "spdx-validation",
+    "version": "0.0.0",
     "main": "./dist/src/index.js",
     "module": "./dist/src/index.mjs",
     "types": "./dist/src/index.d.ts",

--- a/packages/validation-helpers/package.json
+++ b/packages/validation-helpers/package.json
@@ -1,5 +1,6 @@
 {
     "name": "validation-helpers",
+    "version": "0.0.0",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Adds `"version": "0.0.0"` to the five internal workspace packages that had no version field: `common-helpers`, `database`, `s3-helpers`, `spdx-validation`, `validation-helpers`

## Why

ORT's NPM analyzer builds package identifiers as `NPM::<name>:<version>`. Without a `version` field the identifier
becomes e.g. `NPM::common-helpers:` (empty version), which ORT cannot match to any resolved package — causing the
analyzer job to fail entirely with:

> The following references do not actually refer to packages: 'NPM::common-helpers:', 'NPM::database:', 'NPM::s3-helpers:', 'NPM::spdx-validation:', 'NPM::validation-helpers:'

`0.0.0` is the standard convention for private, unpublished monorepo packages. Since none of these are published to a registry, the version value is arbitrary — ORT just needs it to be non-empty.

## Verification

Fix was validated by re-running ORT analysis against this branch. The analyzer completed successfully with no recurrence of the missing-package-reference error.