### PR TITLE
Small changes to environment variable handling in workflows

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,6 @@ jobs:
     test:
         timeout-minutes: 60
         runs-on: ubuntu-latest
-        environment: test-environment
         env:
             DATABASE_URL: ${{ vars.DATABASE_URL }}
         steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,6 @@ jobs:
         environment: test-environment
         env:
             DATABASE_URL: ${{ vars.DATABASE_URL }}
-            NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -17,7 +17,6 @@ jobs:
     unittest:
         name: Unit testing
         runs-on: ubuntu-latest
-        environment: unittest-environment
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,7 +36,7 @@ jobs:
             - name: Run prisma generate
               run: npm run db:generate
               env:
-                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  DATABASE_URL: ${{ vars.DATABASE_URL }}
 
             - name: Build project
               run: npm run build
@@ -49,4 +48,4 @@ jobs:
               run: npm run test
               continue-on-error: false
               env:
-                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  DATABASE_URL: ${{ vars.DATABASE_URL }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,4 +50,3 @@ jobs:
               continue-on-error: false
               env:
                   DATABASE_URL: ${{ secrets.DATABASE_URL }}
-                  SCANNER_URL: ${{ secrets.SCANNER_URL }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
                 - NEXT_PUBLIC_API_URL=http://api:3001/api/
         environment:
             - NEXTAUTH_URL=http://clearance-ui:3000
-            - NEXTAUTH_SECRET=$NEXTAUTH_SECRET
+            - NEXTAUTH_SECRET=secret
             - KEYCLOAK_URL=http://auth:8080
         ports:
             - 3002:3000


### PR DESCRIPTION
The Unit-test and Playwright workflows no longer need environments with restrictions to access secrets, so remove those environments from the workflows altogether. One remaining variable is read from repository variables for convenience, as it's referenced in several places. Others are removed/hard-coded.

This should make it so that workflows can access the needed variables even if the PR comes from a fork.